### PR TITLE
Rename TRUSTED_PROXIES to HEGEL_TRUSTED_PROXIES

### DIFF
--- a/tinkerbell/hegel/templates/deployment.yaml
+++ b/tinkerbell/hegel/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           - {{ . }}
           {{- end }}
           env:
-            - name: TRUSTED_PROXIES
+            - name: HEGEL_TRUSTED_PROXIES
               value: {{ .Values.hegel.trustedProxies }}
             {{- range $i, $env := .Values.hegel.env }}
             - name: {{ $env.name | quote }}


### PR DESCRIPTION
Hegel replaced the TRUSTED_PROXIES environment variable with HEGEL_TRUSTED_PROXIES. Since TRUSTED_PROXIES was removed, the helm chart no longer works. This updates it to used the correct environment variable.

Signed-off-by: Thomas Miller <git@me.tmiller.dev>