### PR TITLE
Fix loadBalancerIP value to match expected in service.yaml:

### DIFF
--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -5,7 +5,7 @@ stack:
     type: LoadBalancer
   selector:
     app: tink-stack
-  loadbalancerIP: 192.168.2.111
+  loadBalancerIP: 192.168.2.111
   lbClass: kube-vip.io/kube-vip-class
   image: nginx:1.23.1
   hook:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This fixes the issue in the released chart version v0.1.0, where the `loadBalancerIP` is not being set for the stack service spec.

## Why is this needed

<!--- Link to issue you have raised -->
The released chart version v0.1.0 is broken. Stack service never gets a load balancer IP.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Install the helm chart from `ghcr.io`.
```bash
 helm install oci://ghcr.io/tinkerbell/charts/stack stack-release --version 0.1.0 --create-namespace --namespace tink-system --wait --set "boots.boots.trustedProxies=${trusted_proxies}" --set "hegel.hegel.trustedProxies=${trusted_proxies}"
```
Observe that the `tink-stack` service doesn't get an `External-IP`.
```bash
NAMESPACE     NAME             TYPE           CLUSTER-IP      EXTERNAL-IP  PORT(S)                                          AGE
tink-system   tink-stack       LoadBalancer   10.43.113.46    <pending>  50061:30998/TCP,42113:30730/TCP,8080:32531/TCP 9m2s
```

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
