### PR TITLE
Update Hegel appVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# charts
-Tinkerbell Helm Charts 
+# Tinkerbell Helm Charts
+
+Install the Tinkerbell stack to a Kubernetes cluster using the familiar Helm tool.
+
+See the [chart README](/tinkerbell/stack/README.md) for configuration details.

--- a/tinkerbell/hegel/Chart.yaml
+++ b/tinkerbell/hegel/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.0"
+appVersion: "0.8.0"

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.1.0
 - name: hegel
   repository: file://../hegel
-  version: 0.2.0
-digest: sha256:1722a00c8ac9f6e22db77e3ca14b27e637fe9bb7cd9fdb71064c4cffea49da2c
-generated: "2022-10-25T21:49:10.204518202Z"
+  version: 0.2.1
+digest: sha256:fd018a6712761a750cdc90a2e47b1589408224df62fd057b3f14b6a776ce774f
+generated: "2022-10-30T10:41:59.101043-04:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -24,28 +24,28 @@ version: 0.1.2
 appVersion: "0.1.0"
 
 dependencies:
-- name: tink
-  #alias: tinkChart
-  version: "0.1.0"
-  repository: "file://../tink"
-  import-values:
-  - child: tink
-    parent: tink
-- name: boots
-  #alias: bootsChart
-  version: "0.1.0"
-  repository: "file://../boots"
-  import-values:
-  - child: boots
-    parent: boots
-- name: rufio
-  #alias: rufioChart
-  version: "0.1.0"
-  repository: "file://../rufio"
-- name: hegel
-  #alias: hegelChart
-  version: "0.2.0"
-  repository: "file://../hegel"
-  import-values:
-  - child: hegel
-    parent: hegel
+  - name: tink
+    #alias: tinkChart
+    version: "0.1.0"
+    repository: "file://../tink"
+    import-values:
+      - child: tink
+        parent: tink
+  - name: boots
+    #alias: bootsChart
+    version: "0.1.0"
+    repository: "file://../boots"
+    import-values:
+      - child: boots
+        parent: boots
+  - name: rufio
+    #alias: rufioChart
+    version: "0.1.0"
+    repository: "file://../rufio"
+  - name: hegel
+    #alias: hegelChart
+    version: "0.2.1"
+    repository: "file://../hegel"
+    import-values:
+      - child: hegel
+        parent: hegel


### PR DESCRIPTION
Update the Hegel chart's `appVersion` property to match the Hegel version being used. As per the Helm recommendations, this also forces a patch number increase to the Chart version.

Closes #16 