### PR TITLE
Make Hegel and Boots trusted proxies required

### DIFF
--- a/tinkerbell/boots/templates/deployment.yaml
+++ b/tinkerbell/boots/templates/deployment.yaml
@@ -34,16 +34,12 @@ spec:
           {{- end }}
           {{- end }}
           env:
-            {{ with .Values.boots.trustedProxies }}
             - name: TRUSTED_PROXIES
-              value: {{ . | quote }}
-            {{- end }}
-          {{- if .Values.boots.env }}
+              value: {{ required "missing boots.trustedProxies" .Values.boots.trustedProxies | quote }}
             {{- range $i, $env := .Values.boots.env }}
             - name: {{ $env.name | quote }}
               value: {{ $env.value | quote }}
             {{- end }}
-          {{- end }}
           {{- if not .Values.boots.hostNetwork }}
           ports:
             {{- range .Values.boots.ports }}

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -15,7 +15,7 @@ boots: # a top-level key like this enables importing of all sub-keys in parent c
       memory: 64Mi
   roleName: boots-role
   roleBindingName: boots-rolebinding
-  trustedProxies: 192.168.0.0/16 # comma-separated list of trusted proxies
+  trustedProxies: ""
   ports:
   - name: boots-dhcp
     port: 67

--- a/tinkerbell/hegel/templates/deployment.yaml
+++ b/tinkerbell/hegel/templates/deployment.yaml
@@ -32,10 +32,8 @@ spec:
           - {{ . }}
           {{- end }}
           env:
-            {{- with .Values.hegel.trustedProxies }}
             - name: HEGEL_TRUSTED_PROXIES
-              value: {{ . | quote }}
-            {{- end }}
+              value: {{ required "missing hegel.trustedProxies" .Values.hegel.trustedProxies | quote }}
             {{- range $i, $env := .Values.hegel.env }}
             - name: {{ $env.name | quote }}
               value: {{ $env.value | quote }}


### PR DESCRIPTION
There's no way to deploy Boots or Hegel such that trusted proxies aren't required so we should error out if not present.