### PR TITLE
Update Kubevip version and interface and Boots deployment strategy:

### DIFF
--- a/tinkerbell/boots/Chart.yaml
+++ b/tinkerbell/boots/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/boots/templates/deployment.yaml
+++ b/tinkerbell/boots/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       {{- with .Values.boots.selector }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+  strategy:
+    type: {{ .Values.boots.deployment.strategy.type }}
   template:
     metadata:
       labels:

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -15,6 +15,9 @@ boots: # a top-level key like this enables importing of all sub-keys in parent c
       memory: 64Mi
   roleName: boots-role
   roleBindingName: boots-rolebinding
+  deployment:
+    strategy:
+      type: Recreate
   trustedProxies: ""
   ports:
   - name: boots-dhcp

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.1.0
 - name: boots
   repository: file://../boots
-  version: 0.1.0
+  version: 0.1.1
 - name: rufio
   repository: file://../rufio
   version: 0.1.0
 - name: hegel
   repository: file://../hegel
   version: 0.2.2
-digest: sha256:09ae69ca35720def262697293436452b5f95760ae66e42f7955a4ac7de148efe
-generated: "2022-12-15T17:41:41.395251-06:00"
+digest: sha256:7ce3dc41aa43fd4e9fb09bc698bbd67ad94d38f189970a7726002ec32873aea3
+generated: "2022-12-16T12:32:07.338972972-07:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
         parent: tink
   - name: boots
     #alias: bootsChart
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../boots"
     import-values:
       - child: boots

--- a/tinkerbell/stack/templates/kubevip.yaml
+++ b/tinkerbell/stack/templates/kubevip.yaml
@@ -27,8 +27,10 @@ spec:
           value: "true"
         - name: svc_election
           value: "true"
+        {{- if .Values.stack.kubevip.interface }}
         - name: vip_interface
           value: {{ .Values.stack.kubevip.interface }}
+        {{- end }}
         image: {{ .Values.stack.kubevip.image }}
         imagePullPolicy: {{ .Values.stack.kubevip.imagePullPolicy }}
         name: {{ .Values.stack.kubevip.name }}

--- a/tinkerbell/stack/templates/kubevip.yaml
+++ b/tinkerbell/stack/templates/kubevip.yaml
@@ -27,9 +27,9 @@ spec:
           value: "true"
         - name: svc_election
           value: "true"
-        {{- if .Values.stack.kubevip.interface }}
+        {{- with .Values.stack.kubevip.interface }}
         - name: vip_interface
-          value: {{ .Values.stack.kubevip.interface }}
+          value: {{ . }}
         {{- end }}
         image: {{ .Values.stack.kubevip.image }}
         imagePullPolicy: {{ .Values.stack.kubevip.imagePullPolicy }}

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -25,11 +25,10 @@ stack:
   kubevip:
     enabled: true
     name: kube-vip
-    image: ghcr.io/kube-vip/kube-vip:v0.5.0
+    image: ghcr.io/kube-vip/kube-vip:v0.5.7
     imagePullPolicy: IfNotPresent
     roleName: kube-vip-role
     roleBindingName: kube-vip-rolebinding
-    interface: eno1
 
 # boots chart overrides
 boots:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Removing the requirement for an interface for Kubevip allows Kubevip to auto discover the interface to use. Kubevip does this by looking for the interface that holds the default route.

Updating Boots' deployment strategy fixes an issue with single node deployments being unable to upgrade Boots because of host ports being in use.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #19 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
