### PR TITLE
Simplify values yaml by removing nested keys for each chart

### DIFF
--- a/tinkerbell/boots/templates/deployment.yaml
+++ b/tinkerbell/boots/templates/deployment.yaml
@@ -1,65 +1,65 @@
-{{- if .Values.boots.deploy }}
+{{- if .Values.deploy }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ .Values.boots.name }}
-  name:  {{ .Values.boots.name }}
+    app: {{ .Values.name }}
+  name:  {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: {{ .Values.boots.replicas }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.boots.name }}
+      app: {{ .Values.name }}
       stack: tinkerbell
-      {{- with .Values.boots.selector }}
+      {{- with .Values.selector }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
   strategy:
-    type: {{ .Values.boots.deployment.strategy.type }}
+    type: {{ .Values.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app: {{ .Values.boots.name }}
+        app: {{ .Values.name }}
         stack: tinkerbell
-        {{- with .Values.boots.selector }}
+        {{- with .Values.selector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       containers:
-        - image: {{ .Values.boots.image }}
-          imagePullPolicy: {{ .Values.boots.imagePullPolicy }}
-          {{- if .Values.boots.args }}
+        - image: {{ .Values.image }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- if .Values.args }}
           args: 
-          {{- range .Values.boots.args }}
+          {{- range .Values.args }}
             - {{ . }}
           {{- end }}
           {{- end }}
           env:
             - name: TRUSTED_PROXIES
-              value: {{ required "missing boots.trustedProxies" .Values.boots.trustedProxies | quote }}
-            {{- range $i, $env := .Values.boots.env }}
+              value: {{ required "missing trustedProxies" .Values.trustedProxies | quote }}
+            {{- range $i, $env := .Values.env }}
             - name: {{ $env.name | quote }}
               value: {{ $env.value | quote }}
             {{- end }}
-          {{- if not .Values.boots.hostNetwork }}
+          {{- if not .Values.hostNetwork }}
           ports:
-            {{- range .Values.boots.ports }}
+            {{- range .Values.ports }}
             - containerPort: {{ .targetPort }}
               name: {{ .name }}
               protocol: {{ .protocol }}
             {{- end }}
           {{- end }}
-          name: {{ .Values.boots.name }}
+          name: {{ .Values.name }}
           resources:
             limits:
-              cpu: {{ .Values.boots.resources.limits.cpu }}
-              memory: {{ .Values.boots.resources.limits.memory }}
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
             requests:
-              cpu: {{ .Values.boots.resources.requests.cpu }}
-              memory: {{ .Values.boots.resources.requests.memory }}
-      serviceAccountName: {{ .Values.boots.name }}
-      {{- if .Values.boots.hostNetwork }}
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+      serviceAccountName: {{ .Values.name }}
+      {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
 {{- end }}

--- a/tinkerbell/boots/templates/role.yaml
+++ b/tinkerbell/boots/templates/role.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.boots.deploy }}
+{{- if .Values.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.boots.roleName }}
+  name: {{ .Values.roleName }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
   - apiGroups:

--- a/tinkerbell/boots/templates/rolebinding.yaml
+++ b/tinkerbell/boots/templates/rolebinding.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.boots.deploy }}
+{{- if .Values.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.boots.roleBindingName }}
+  name: {{ .Values.roleBindingName }}
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.boots.roleName }}
+  name: {{ .Values.roleName }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.boots.name }}
+    name: {{ .Values.name }}
     namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/boots/templates/service-account.yaml
+++ b/tinkerbell/boots/templates/service-account.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.boots.deploy }}
+{{- if .Values.deploy }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.boots.name }}
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/boots/templates/service.yaml
+++ b/tinkerbell/boots/templates/service.yaml
@@ -1,20 +1,20 @@
-{{- if .Values.boots.deploy -}}
+{{- if .Values.deploy -}}
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ .Values.boots.name }}
-  name: {{ .Values.boots.name }}
+    app: {{ .Values.name }}
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   clusterIP: None
   ports:
-  {{- range .Values.boots.ports }}
+  {{- range .Values.ports }}
   - name: {{ .name }}
     port: {{ .port }}
     targetPort: {{ .targetPort }}
     protocol: {{ .protocol }}
   {{- end }}
   selector:
-    app: {{ .Values.boots.name }}
+    app: {{ .Values.name }}
 {{- end -}}

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -1,57 +1,56 @@
-boots: # a top-level key like this enables importing of all sub-keys in parent charts
-  deploy: true
-  hostNetwork: true
-  name: boots
-  image: quay.io/tinkerbell/boots:v0.8.0
-  imagePullPolicy: IfNotPresent
-  replicas: 1
-  args: ["-dhcp-addr=0.0.0.0:67"]
-  resources:
-    limits:
-      cpu: 500m
-      memory: 128Mi
-    requests:
-      cpu: 10m
-      memory: 64Mi
-  roleName: boots-role
-  roleBindingName: boots-rolebinding
-  deployment:
-    strategy:
-      type: Recreate
-  trustedProxies: ""
-  ports:
-  - name: boots-dhcp
-    port: 67
-    protocol: UDP
-    targetPort: 67
-  - name: boots-http
-    port: 80
-    protocol: TCP
-    targetPort: 80
-  - name: boots-syslog
-    port: 514
-    protocol: UDP
-    targetPort: 514
-  - name: boots-tftp
-    port: 69
-    protocol: UDP
-    targetPort: 69
-  env:
-  - name: DATA_MODEL_VERSION
-    value: "kubernetes"
-  - name: FACILITY_CODE
-    value: "lab1"
-  - name: HTTP_BIND
-    value: ":80"
-  - name: MIRROR_BASE_URL
-    value: http://192.168.1.94:8080
-  - name: PUBLIC_IP
-    value: 192.168.1.94
-  - name: PUBLIC_SYSLOG_FQDN
-    value: 192.168.1.94
-  - name: SYSLOG_BIND
-    value: 0.0.0.0:514
-  - name: TINKERBELL_GRPC_AUTHORITY
-    value: 192.168.1.94:42113
-  - name: TINKERBELL_TLS
-    value: "false"
+deploy: true
+hostNetwork: true
+name: boots
+image: quay.io/tinkerbell/boots:v0.8.0
+imagePullPolicy: IfNotPresent
+replicas: 1
+args: ["-dhcp-addr=0.0.0.0:67"]
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+roleName: boots-role
+roleBindingName: boots-rolebinding
+deployment:
+  strategy:
+    type: Recreate
+trustedProxies: ""
+ports:
+- name: boots-dhcp
+  port: 67
+  protocol: UDP
+  targetPort: 67
+- name: boots-http
+  port: 80
+  protocol: TCP
+  targetPort: 80
+- name: boots-syslog
+  port: 514
+  protocol: UDP
+  targetPort: 514
+- name: boots-tftp
+  port: 69
+  protocol: UDP
+  targetPort: 69
+env:
+- name: DATA_MODEL_VERSION
+  value: "kubernetes"
+- name: FACILITY_CODE
+  value: "lab1"
+- name: HTTP_BIND
+  value: ":80"
+- name: MIRROR_BASE_URL
+  value: http://192.168.1.94:8080
+- name: PUBLIC_IP
+  value: 192.168.1.94
+- name: PUBLIC_SYSLOG_FQDN
+  value: 192.168.1.94
+- name: SYSLOG_BIND
+  value: 0.0.0.0:514
+- name: TINKERBELL_GRPC_AUTHORITY
+  value: 192.168.1.94:42113
+- name: TINKERBELL_TLS
+  value: "false"

--- a/tinkerbell/hegel/templates/deployment.yaml
+++ b/tinkerbell/hegel/templates/deployment.yaml
@@ -1,55 +1,55 @@
-{{- if .Values.hegel.deploy }}
+{{- if .Values.deploy }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ .Values.hegel.name }}
-  name:  {{ .Values.hegel.name }}
+    app: {{ .Values.name }}
+  name:  {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: {{ .Values.hegel.replicas }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.hegel.name }}
+      app: {{ .Values.name }}
       stack: tinkerbell
-      {{- with .Values.hegel.selector }}
+      {{- with .Values.selector }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
   template:
     metadata:
       labels:
-        app: {{ .Values.hegel.name }}
+        app: {{ .Values.name }}
         stack: tinkerbell
-        {{- with .Values.hegel.selector }}
+        {{- with .Values.selector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       containers:
         - args:
           - --backend=kubernetes
-          - --http-port={{ .Values.hegel.deployment.port }}
-          {{- range .Values.hegel.args }}
+          - --http-port={{ .Values.deployment.port }}
+          {{- range .Values.args }}
           - {{ . }}
           {{- end }}
           env:
             - name: HEGEL_TRUSTED_PROXIES
-              value: {{ required "missing hegel.trustedProxies" .Values.hegel.trustedProxies | quote }}
-            {{- range $i, $env := .Values.hegel.env }}
+              value: {{ required "missing trustedProxies" .Values.trustedProxies | quote }}
+            {{- range $i, $env := .Values.env }}
             - name: {{ $env.name | quote }}
               value: {{ $env.value | quote }}
             {{- end }}
-          image: {{ .Values.hegel.image }}
-          imagePullPolicy: {{ .Values.hegel.imagePullPolicy }}
-          name: {{ .Values.hegel.name }}
+          image: {{ .Values.image }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          name: {{ .Values.name }}
           ports:
-            - containerPort: {{ .Values.hegel.deployment.port }}
-              name: {{ .Values.hegel.deployment.portName }}
+            - containerPort: {{ .Values.deployment.port }}
+              name: {{ .Values.deployment.portName }}
           resources:
             limits:
-              cpu: {{ .Values.hegel.resources.limits.cpu }}
-              memory: {{ .Values.hegel.resources.limits.memory }}
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
             requests:
-              cpu: {{ .Values.hegel.resources.requests.cpu }}
-              memory: {{ .Values.hegel.resources.requests.memory }}
-      serviceAccountName: {{ .Values.hegel.name }}
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+      serviceAccountName: {{ .Values.name }}
 {{- end }}

--- a/tinkerbell/hegel/templates/role.yaml
+++ b/tinkerbell/hegel/templates/role.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.hegel.deploy }}
+{{- if .Values.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.hegel.roleName }}
+  name: {{ .Values.roleName }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
   - apiGroups:

--- a/tinkerbell/hegel/templates/rolebinding.yaml
+++ b/tinkerbell/hegel/templates/rolebinding.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.hegel.deploy }}
+{{- if .Values.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.hegel.roleBindingName }}
+  name: {{ .Values.roleBindingName }}
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Values.hegel.roleName }}
+  name: {{ .Values.roleName }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.hegel.name }}
+    name: {{ .Values.name }}
     namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/hegel/templates/service-account.yaml
+++ b/tinkerbell/hegel/templates/service-account.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.hegel.deploy }}
+{{- if .Values.deploy }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.hegel.name }}
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/hegel/templates/service.yaml
+++ b/tinkerbell/hegel/templates/service.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.hegel.deploy -}}
+{{- if .Values.deploy -}}
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ .Values.hegel.name }}
-  name: {{ .Values.hegel.name }}
+    app: {{ .Values.name }}
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   clusterIP: None
   ports:
-  - port: {{ .Values.hegel.service.port }}
+  - port: {{ .Values.service.port }}
     protocol: TCP
-    targetPort: {{ .Values.hegel.deployment.portName }}
+    targetPort: {{ .Values.deployment.portName }}
   selector:
-    app: {{ .Values.hegel.name }}
+    app: {{ .Values.name }}
 {{- end -}}

--- a/tinkerbell/hegel/values.yaml
+++ b/tinkerbell/hegel/values.yaml
@@ -1,21 +1,20 @@
-hegel: # a top-level key like this enables importing of all sub-keys in parent charts
-  deploy: true
-  trustedProxies: ""
-  name: hegel
-  image: quay.io/tinkerbell/hegel:v0.10.1
-  imagePullPolicy: IfNotPresent
-  replicas: 1
-  service:
-    port: 50061
-  deployment:
-    port: 50061
-    portName: hegel-http
-  resources:
-    limits:
-      cpu: 500m
-      memory: 128Mi
-    requests:
-      cpu: 10m
-      memory: 64Mi
-  roleName: hegel-role
-  roleBindingName: hegel-rolebinding
+deploy: true
+trustedProxies: ""
+name: hegel
+image: quay.io/tinkerbell/hegel:v0.10.1
+imagePullPolicy: IfNotPresent
+replicas: 1
+service:
+  port: 50061
+deployment:
+  port: 50061
+  portName: hegel-http
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+roleName: hegel-role
+roleBindingName: hegel-rolebinding

--- a/tinkerbell/rufio/templates/cluster-role-binding.yaml
+++ b/tinkerbell/rufio/templates/cluster-role-binding.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.rufio.deploy }}
+{{- if .Values.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.rufio.managerRoleBindingName }}
+  name: {{ .Values.managerRoleBindingName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.rufio.managerRoleName }}
+  name: {{ .Values.managerRoleName }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.rufio.serviceAccountName }}
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/rufio/templates/cluster-role.yaml
+++ b/tinkerbell/rufio/templates/cluster-role.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.rufio.deploy }}---
+{{- if .Values.deploy }}---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: {{ .Values.rufio.managerRoleName }}
+  name: {{ .Values.managerRoleName }}
 rules:
 - apiGroups:
   - ""

--- a/tinkerbell/rufio/templates/deployment.yaml
+++ b/tinkerbell/rufio/templates/deployment.yaml
@@ -1,16 +1,16 @@
-{{- if .Values.rufio.deploy }}
+{{- if .Values.deploy }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ .Values.rufio.name }}
+    app: {{ .Values.name }}
     control-plane: controller-manager
-  name: {{ .Values.rufio.name }}
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Values.rufio.name }}
+      app: {{ .Values.name }}
       control-plane: controller-manager
       stack: tinkerbell
   replicas: 1
@@ -19,7 +19,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        app: {{ .Values.rufio.name }}
+        app: {{ .Values.name }}
         control-plane: controller-manager
         stack: tinkerbell
     spec:
@@ -30,7 +30,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: {{ .Values.rufio.image }}
+        image: {{ .Values.image }}
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
@@ -50,11 +50,11 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: {{ .Values.rufio.resources.limits.cpu }}
-            memory: {{ .Values.rufio.resources.limits.memory }}
+            cpu: {{ .Values.resources.limits.cpu }}
+            memory: {{ .Values.resources.limits.memory }}
           requests:
-            cpu: {{ .Values.rufio.resources.requests.cpu }}
-            memory: {{ .Values.rufio.resources.requests.memory }}
-      serviceAccountName: {{ .Values.rufio.serviceAccountName }}
+            cpu: {{ .Values.resources.requests.cpu }}
+            memory: {{ .Values.resources.requests.memory }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
       terminationGracePeriodSeconds: 10
 {{- end }}

--- a/tinkerbell/rufio/templates/leader-election-role-binding.yaml
+++ b/tinkerbell/rufio/templates/leader-election-role-binding.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.rufio.deploy }}
+{{- if .Values.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.rufio.rufioLeaderElectionRoleBindingName }}
+  name: {{ .Values.rufioLeaderElectionRoleBindingName }}
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Values.rufio.rufioLeaderElectionRoleName }}
+  name: {{ .Values.rufioLeaderElectionRoleName }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.rufio.serviceAccountName }}
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/rufio/templates/leader-election-role.yaml
+++ b/tinkerbell/rufio/templates/leader-election-role.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.rufio.deploy }}
+{{- if .Values.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.rufio.rufioLeaderElectionRoleName }}
+  name: {{ .Values.rufioLeaderElectionRoleName }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups:

--- a/tinkerbell/rufio/templates/service-account.yaml
+++ b/tinkerbell/rufio/templates/service-account.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.rufio.deploy }}
+{{- if .Values.deploy }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.rufio.serviceAccountName }}
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/rufio/values.yaml
+++ b/tinkerbell/rufio/values.yaml
@@ -1,19 +1,18 @@
-rufio: # a top-level key like this enables importing of all sub-keys in parent charts
-  deploy: true
-  name: rufio
-  image: quay.io/tinkerbell/rufio:v0.1.0
-  resources:
-    limits:
-      cpu: 500m
-      memory: 128Mi
-    requests:
-      cpu: 10m
-      memory: 64Mi
-  serviceAccountName: rufio-controller-manager
-  rufioLeaderElectionRoleName: rufio-leader-election-role
-  rufioSecretsViewerRoleName: rufio-secrets-viewer-role
-  managerRoleName: rufio-manager-role
-  rufioLeaderElectionRoleBindingName: rufio-leader-election-rolebinding
-  rufioSecretsViewerRoleBindingName: rufio-secrets-viewer-rolebinding
-  managerRoleBindingName: rufio-manager-rolebinding
-  managerConfigmapName: rufio-manager-config
+deploy: true
+name: rufio
+image: quay.io/tinkerbell/rufio:v0.1.0
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+serviceAccountName: rufio-controller-manager
+rufioLeaderElectionRoleName: rufio-leader-election-role
+rufioSecretsViewerRoleName: rufio-secrets-viewer-role
+managerRoleName: rufio-manager-role
+rufioLeaderElectionRoleBindingName: rufio-leader-election-rolebinding
+rufioSecretsViewerRoleBindingName: rufio-secrets-viewer-rolebinding
+managerRoleBindingName: rufio-manager-rolebinding
+managerConfigmapName: rufio-manager-config

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: hegel
   repository: file://../hegel
   version: 0.2.2
-digest: sha256:7ce3dc41aa43fd4e9fb09bc698bbd67ad94d38f189970a7726002ec32873aea3
-generated: "2022-12-16T12:32:07.338972972-07:00"
+digest: sha256:423e89a5b2d9acc5c098f92e62a850878b5f0a0d19041b0f894d641bd1df0c37
+generated: "2022-12-16T14:46:43.117966882-05:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,27 +25,14 @@ appVersion: "0.2.0"
 
 dependencies:
   - name: tink
-    #alias: tinkChart
     version: "0.1.0"
     repository: "file://../tink"
-    import-values:
-      - child: tink
-        parent: tink
   - name: boots
-    #alias: bootsChart
     version: "0.1.1"
     repository: "file://../boots"
-    import-values:
-      - child: boots
-        parent: boots
   - name: rufio
-    #alias: rufioChart
     version: "0.1.0"
     repository: "file://../rufio"
   - name: hegel
-    #alias: hegelChart
     version: "0.2.2"
     repository: "file://../hegel"
-    import-values:
-      - child: hegel
-        parent: hegel

--- a/tinkerbell/stack/README.md
+++ b/tinkerbell/stack/README.md
@@ -7,7 +7,7 @@ This chart installs the full Tinkerbell stack.
 ```bash
 helm dependency build stack/
 trusted_proxies=$(kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}' | tr ' ' ',')
-helm install stack-release stack/ --create-namespace --namespace tink-system --wait --set "boots.boots.trustedProxies=${trusted_proxies}" --set "hegel.hegel.trustedProxies=${trusted_proxies}"
+helm install stack-release stack/ --create-namespace --namespace tink-system --wait --set "boots.trustedProxies=${trusted_proxies}" --set "hegel.trustedProxies=${trusted_proxies}"
 ```
 
 ## Introduction
@@ -36,11 +36,11 @@ The stack chart does not use an ingress object and controller. This is because m
 You'll want to customize the IP used for the load balancer in the `values.yaml` file. The following places should all be the same IP:
 
 - `stack.loadbalancerIP`
-- `boots.boots.env[3].value` (`MIRROR_BASE_URL`)
-- `boots.boots.env[4].value` (`BOOTS_OSIE_PATH_OVERRIDE`)
-- `boots.boots.env[5].value` (`PUBLIC_IP`)
-- `boots.boots.env[6].value` (`PUBLIC_SYSLOG_FQDN`)
-- `boots.boots.env[8].value` (`TINKERBELL_GRPC_AUTHORITY`)
+- `boots.env[3].value` (`MIRROR_BASE_URL`)
+- `boots.env[4].value` (`BOOTS_OSIE_PATH_OVERRIDE`)
+- `boots.env[5].value` (`PUBLIC_IP`)
+- `boots.env[6].value` (`PUBLIC_SYSLOG_FQDN`)
+- `boots.env[8].value` (`TINKERBELL_GRPC_AUTHORITY`)
 
 You'll also want to customize the interface that should be used to advertize the load balancer IP.
 
@@ -51,7 +51,7 @@ Now, deploy the chart.
 ```bash
 helm dependency build stack/
 trusted_proxies=$(kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}' | tr ' ' ',')
-helm install stack-release stack/ --create-namespace --namespace tink-system --wait --set "boots.boots.trustedProxies=${trusted_proxies}" --set "hegel.hegel.trustedProxies=${trusted_proxies}"
+helm install stack-release stack/ --create-namespace --namespace tink-system --wait --set "boots.trustedProxies=${trusted_proxies}" --set "hegel.trustedProxies=${trusted_proxies}"
 ```
 
 These commands install the Tinkerbell Stack chart in the `tink-system` namespace with the release name of `stack-release`.
@@ -122,4 +122,4 @@ hegel:
 
 | Name | Description | Value |
 | ---- | ----------- | ----- |
-| `boots.boots.hostNetwork` | Whether to deploy Boots using `hostNetwork` on the pod spec. When `true` Boots will be able to receive DHCP broadcast messages. If `false`, Boots will be behind the load balancer VIP and will need to receive DHCP requests via unicast. | `true` |  
+| `boots.hostNetwork` | Whether to deploy Boots using `hostNetwork` on the pod spec. When `true` Boots will be able to receive DHCP broadcast messages. If `false`, Boots will be behind the load balancer VIP and will need to receive DHCP requests via unicast. | `true` |  

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -32,49 +32,45 @@ stack:
 
 # boots chart overrides
 boots:
-  boots:
-    image: quay.io/tinkerbell/boots:v0.8.0
-    env:
-      - name: DATA_MODEL_VERSION
-        value: "kubernetes"
-      - name: FACILITY_CODE
-        value: "lab1"
-      - name: HTTP_BIND
-        value: ":80"
-      - name: MIRROR_BASE_URL
-        value: http://192.168.2.111:8080
-      - name: BOOTS_OSIE_PATH_OVERRIDE
-        value: http://192.168.2.111:8080
-      - name: PUBLIC_IP
-        value: 192.168.2.111
-      - name: PUBLIC_SYSLOG_FQDN
-        value: 192.168.2.111
-      - name: SYSLOG_BIND
-        value: :514
-      - name: TINKERBELL_GRPC_AUTHORITY
-        value: 192.168.2.111:42113
-      - name: TINKERBELL_TLS
-        value: "false"
-      - name: BOOTS_LOG_LEVEL
-        value: "debug"
-      - name: BOOTS_EXTRA_KERNEL_ARGS
-        value: "tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0"
-    hostNetwork: true
+  image: quay.io/tinkerbell/boots:v0.8.0
+  env:
+    - name: DATA_MODEL_VERSION
+      value: "kubernetes"
+    - name: FACILITY_CODE
+      value: "lab1"
+    - name: HTTP_BIND
+      value: ":80"
+    - name: MIRROR_BASE_URL
+      value: http://192.168.2.111:8080
+    - name: BOOTS_OSIE_PATH_OVERRIDE
+      value: http://192.168.2.111:8080
+    - name: PUBLIC_IP
+      value: 192.168.2.111
+    - name: PUBLIC_SYSLOG_FQDN
+      value: 192.168.2.111
+    - name: SYSLOG_BIND
+      value: :514
+    - name: TINKERBELL_GRPC_AUTHORITY
+      value: 192.168.2.111:42113
+    - name: TINKERBELL_TLS
+      value: "false"
+    - name: BOOTS_LOG_LEVEL
+      value: "debug"
+    - name: BOOTS_EXTRA_KERNEL_ARGS
+      value: "tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0"
+  hostNetwork: true
 
 # hegel chart overrides
 hegel:
-  hegel:
-    image: quay.io/tinkerbell/hegel:v0.10.1
+  image: quay.io/tinkerbell/hegel:v0.10.1
 
 # rufio chart overrides
 rufio:
-  rufio:
-    image: quay.io/tinkerbell/rufio:v0.1.0
+  image: quay.io/tinkerbell/rufio:v0.1.0
 
 # tink chart overrides
 tink:
-  tink:
-    controller:
-      image: quay.io/tinkerbell/tink-controller:v0.8.0
-    server:
-      image: quay.io/tinkerbell/tink:v0.8.0
+  controller:
+    image: quay.io/tinkerbell/tink-controller:v0.8.0
+  server:
+    image: quay.io/tinkerbell/tink:v0.8.0

--- a/tinkerbell/tink/templates/tink-controller/cluster-role-binding.yaml
+++ b/tinkerbell/tink/templates/tink-controller/cluster-role-binding.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.tink.controller.deploy }}
+{{- if .Values.controller.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name:  {{ .Values.tink.controller.roleBindingName }}
+  name:  {{ .Values.controller.roleBindingName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.tink.controller.roleName }}
+  name: {{ .Values.controller.roleName }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.tink.controller.name }}
+    name: {{ .Values.controller.name }}
     namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/tink/templates/tink-controller/cluster-role.yaml
+++ b/tinkerbell/tink/templates/tink-controller/cluster-role.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.tink.controller.deploy }}
+{{- if .Values.controller.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.tink.controller.roleName }}
+  name: {{ .Values.controller.roleName }}
 rules:
   - apiGroups:
       - tinkerbell.org

--- a/tinkerbell/tink/templates/tink-controller/deployment.yaml
+++ b/tinkerbell/tink/templates/tink-controller/deployment.yaml
@@ -1,37 +1,37 @@
-{{- if .Values.tink.controller.deploy }}
+{{- if .Values.controller.deploy }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ .Values.tink.controller.name }}
-  name: {{ .Values.tink.controller.name }}
+    app: {{ .Values.controller.name }}
+  name: {{ .Values.controller.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: {{ .Values.tink.controller.replicas }}
+  replicas: {{ .Values.controller.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.tink.controller.name }}
+      app: {{ .Values.controller.name }}
   template:
     metadata:
       labels:
-        app: {{ .Values.tink.controller.name }}
+        app: {{ .Values.controller.name }}
     spec:
       containers:
-        - image: {{ .Values.tink.controller.image }}
-          imagePullPolicy: {{ .Values.tink.controller.imagePullPolicy }}
-          {{- if .Values.tink.controller.args }}
+        - image: {{ .Values.controller.image }}
+          imagePullPolicy: {{ .Values.controller.imagePullPolicy }}
+          {{- if .Values.controller.args }}
           args: 
-          {{- range .Values.tink.controller.args }}
+          {{- range .Values.controller.args }}
             - {{ . }}
           {{- end }}
           {{- end }}
-          name: {{ .Values.tink.controller.name }}
+          name: {{ .Values.controller.name }}
           resources:
             limits:
-              cpu: {{ .Values.tink.controller.resources.limits.cpu }}
-              memory: {{ .Values.tink.controller.resources.limits.memory }}
+              cpu: {{ .Values.controller.resources.limits.cpu }}
+              memory: {{ .Values.controller.resources.limits.memory }}
             requests:
-              cpu: {{ .Values.tink.controller.resources.requests.cpu }}
-              memory: {{ .Values.tink.controller.resources.requests.memory }}
-      serviceAccountName: {{ .Values.tink.controller.name }}
+              cpu: {{ .Values.controller.resources.requests.cpu }}
+              memory: {{ .Values.controller.resources.requests.memory }}
+      serviceAccountName: {{ .Values.controller.name }}
 {{- end }}

--- a/tinkerbell/tink/templates/tink-controller/leader-election-role.yaml
+++ b/tinkerbell/tink/templates/tink-controller/leader-election-role.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.tink.controller.deploy }}
+{{- if .Values.controller.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.tink.controller.tinkLeaderElectionRoleName }}
+  name: {{ .Values.controller.tinkLeaderElectionRoleName }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
   - apiGroups:

--- a/tinkerbell/tink/templates/tink-controller/leader-election-rolebinding.yaml
+++ b/tinkerbell/tink/templates/tink-controller/leader-election-rolebinding.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.tink.controller.deploy }}
+{{- if .Values.controller.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.tink.controller.tinkLeaderElectionRoleBindingName }}
+  name: {{ .Values.controller.tinkLeaderElectionRoleBindingName }}
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Values.tink.controller.tinkLeaderElectionRoleName }}
+  name: {{ .Values.controller.tinkLeaderElectionRoleName }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.tink.controller.name }}
+    name: {{ .Values.controller.name }}
     namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/tink/templates/tink-controller/service-account.yaml
+++ b/tinkerbell/tink/templates/tink-controller/service-account.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.tink.controller.deploy }}
+{{- if .Values.controller.deploy }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.tink.controller.name }}
+  name: {{ .Values.controller.name }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/tink/templates/tink-server/deployment.yaml
+++ b/tinkerbell/tink/templates/tink-server/deployment.yaml
@@ -1,47 +1,47 @@
-{{- if .Values.tink.server.deploy }}
+{{- if .Values.server.deploy }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ .Values.tink.server.name }}
-  name: {{ .Values.tink.server.name }}
+    app: {{ .Values.server.name }}
+  name: {{ .Values.server.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: {{ .Values.tink.server.replicas }}
+  replicas: {{ .Values.server.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.tink.server.name }}
+      app: {{ .Values.server.name }}
       stack: tinkerbell
-      {{- with .Values.tink.server.selector }}
+      {{- with .Values.server.selector }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
   template:
     metadata:
       labels:
-        app: {{ .Values.tink.server.name }}
+        app: {{ .Values.server.name }}
         stack: tinkerbell
-        {{- with .Values.tink.server.selector }}
+        {{- with .Values.server.selector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       containers:
         - args:
             - --backend=kubernetes
-            {{- range .Values.tink.server.args }}
+            {{- range .Values.server.args }}
             - {{ . }}
             {{- end }}
-          image: {{ .Values.tink.server.image }}
-          imagePullPolicy: {{ .Values.tink.server.imagePullPolicy }}
+          image: {{ .Values.server.image }}
+          imagePullPolicy: {{ .Values.server.imagePullPolicy }}
           name: server
           ports:
-            - containerPort: {{ .Values.tink.server.deployment.port }}
-              name: {{ .Values.tink.server.deployment.portName }}
+            - containerPort: {{ .Values.server.deployment.port }}
+              name: {{ .Values.server.deployment.portName }}
           resources:
             limits:
-              cpu: {{ .Values.tink.server.resources.limits.cpu }}
-              memory: {{ .Values.tink.server.resources.limits.memory }}
+              cpu: {{ .Values.server.resources.limits.cpu }}
+              memory: {{ .Values.server.resources.limits.memory }}
             requests:
-              cpu: {{ .Values.tink.server.resources.requests.cpu }}
-              memory: {{ .Values.tink.server.resources.requests.memory }}
-      serviceAccountName: {{ .Values.tink.server.name }}
+              cpu: {{ .Values.server.resources.requests.cpu }}
+              memory: {{ .Values.server.resources.requests.memory }}
+      serviceAccountName: {{ .Values.server.name }}
 {{- end }}

--- a/tinkerbell/tink/templates/tink-server/role.yaml
+++ b/tinkerbell/tink/templates/tink-server/role.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.tink.server.deploy }}
+{{- if .Values.server.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.tink.server.roleName }}
+  name: {{ .Values.server.roleName }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
   - apiGroups:

--- a/tinkerbell/tink/templates/tink-server/rolebinding.yaml
+++ b/tinkerbell/tink/templates/tink-server/rolebinding.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.tink.server.deploy }}
+{{- if .Values.server.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.tink.server.roleBindingName }}
+  name: {{ .Values.server.roleBindingName }}
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.tink.server.roleName }}
+  name: {{ .Values.server.roleName }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.tink.server.name }}
+    name: {{ .Values.server.name }}
     namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/tink/templates/tink-server/service-account.yaml
+++ b/tinkerbell/tink/templates/tink-server/service-account.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.tink.server.deploy }}
+{{- if .Values.server.deploy }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.tink.server.name }}
+  name: {{ .Values.server.name }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/tinkerbell/tink/templates/tink-server/service.yaml
+++ b/tinkerbell/tink/templates/tink-server/service.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.tink.server.deploy -}}
+{{- if .Values.server.deploy -}}
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ .Values.tink.server.name }}
-  name: {{ .Values.tink.server.name }}
+    app: {{ .Values.server.name }}
+  name: {{ .Values.server.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   clusterIP: None
   ports:
-  - port: {{ .Values.tink.server.service.port }}
+  - port: {{ .Values.server.service.port }}
     protocol: TCP
-    targetPort: {{ .Values.tink.server.deployment.portName }}
+    targetPort: {{ .Values.server.deployment.portName }}
   selector:
-    app: {{ .Values.tink.server.name }}
+    app: {{ .Values.server.name }}
 {{- end -}}

--- a/tinkerbell/tink/values.yaml
+++ b/tinkerbell/tink/values.yaml
@@ -1,41 +1,40 @@
-tink: # a top-level key like this enables importing of all sub-keys in parent charts  
-  controller:
-    deploy: true
-    name: tink-controller
-    image: quay.io/tinkerbell/tink-controller:v0.8.0
-    imagePullPolicy: IfNotPresent
-    replicas: 1
-    args: []
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
-    roleName: tink-controller-manager-role
-    roleBindingName: tink-controller-manager-rolebinding
-    tinkLeaderElectionRoleName: tink-leader-election-role
-    tinkLeaderElectionRoleBindingName: tink-leader-election-rolebinding
-  
-  server:
-    deploy: true
-    name: tink-server
-    image: quay.io/tinkerbell/tink:v0.8.0
-    imagePullPolicy: IfNotPresent
-    replicas: 1
-    service:
-      port: 42113
-    deployment:
-      port: 42113
-      portName: tink-grpc
-    args: ["--tls=false"]
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
-    roleName: tink-server-role
-    roleBindingName: tink-server-rolebinding
+controller:
+  deploy: true
+  name: tink-controller
+  image: quay.io/tinkerbell/tink-controller:v0.8.0
+  imagePullPolicy: IfNotPresent
+  replicas: 1
+  args: []
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  roleName: tink-controller-manager-role
+  roleBindingName: tink-controller-manager-rolebinding
+  tinkLeaderElectionRoleName: tink-leader-election-role
+  tinkLeaderElectionRoleBindingName: tink-leader-election-rolebinding
+
+server:
+  deploy: true
+  name: tink-server
+  image: quay.io/tinkerbell/tink:v0.8.0
+  imagePullPolicy: IfNotPresent
+  replicas: 1
+  service:
+    port: 42113
+  deployment:
+    port: 42113
+    portName: tink-grpc
+  args: ["--tls=false"]
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  roleName: tink-server-role
+  roleBindingName: tink-server-rolebinding


### PR DESCRIPTION
Each chart specified a top level key to satisfy the parent-child import in the stack chart. The mapping is unnecessary as Helm allows setting of values via the name of dependent charts.

For example:

```
dependencies:
  - name: tink # name of the dependent chart that can be used to reference its values.
    version: "0.1.0"
    repository: "file://../tink"
```

```
helm install --set tink.controller.deploy=false ./tinkerbell/stack
```

```
# values.yaml override
tink:
  controller:
    deploy: false
```

The `stack` chart version has been incremented from minor version 1 to minor 2. This takes into consideration all the other changes we've made recently. The bump is to represent the significant change in values definitions.