### PR TITLE
Update description and value of kubevip.interface in chart README.md

### DIFF
--- a/tinkerbell/stack/README.md
+++ b/tinkerbell/stack/README.md
@@ -96,7 +96,7 @@ helm uninstall stack-release --namespace tink-system
 | `kubevip.imagePullPolicy` | Image pull policy to use for kube-vip | `IfNotPresent` |
 | `kubevip.roleName` | Role name to use for the kube-vip load service | `kube-vip-role` |
 | `kubevip.roleBindingName` | Role binding name to use for the kube-vip load service | `kube-vip-rolebinding` |
-| `kubevip.interface` | Interface to use for advertizing the load balancer IP | `eth0` |
+| `kubevip.interface` | Interface to use for advertizing the load balancer IP. Leaving it unset to allow Kubevip to auto discover the interface to use. | `""` |
 
 ### Tinkerbell Services Parameters
 
@@ -122,4 +122,4 @@ hegel:
 
 | Name | Description | Value |
 | ---- | ----------- | ----- |
-| `boots.hostNetwork` | Whether to deploy Boots using `hostNetwork` on the pod spec. When `true` Boots will be able to receive DHCP broadcast messages. If `false`, Boots will be behind the load balancer VIP and will need to receive DHCP requests via unicast. | `true` |  
+| `boots.hostNetwork` | Whether to deploy Boots using `hostNetwork` on the pod spec. When `true` Boots will be able to receive DHCP broadcast messages. If `false`, Boots will be behind the load balancer VIP and will need to receive DHCP requests via unicast. | `true` |


### PR DESCRIPTION
Signed-off-by: Xiaodong Ye <yeahdongcn@gmail.com>

## Description

<!--- Please describe what this PR is going to change -->
Update description and value of `kubevip.interface` in chart README.md

## Why is this needed
In previous changes, the default value of `kubevip.interface` is removed to let Kubevip auto discover the interface. This PR updates document to align the change.

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
