### PR TITLE
Use trustedProxies values as arrays

### DIFF
--- a/tinkerbell/boots/templates/deployment.yaml
+++ b/tinkerbell/boots/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           {{- end }}
           env:
             - name: TRUSTED_PROXIES
-              value: {{ required "missing trustedProxies" .Values.trustedProxies | quote }}
+              value: {{ join "," .Values.trustedProxies }}
             {{- range $i, $env := .Values.env }}
             - name: {{ $env.name | quote }}
               value: {{ $env.value | quote }}

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -17,7 +17,7 @@ roleBindingName: boots-rolebinding
 deployment:
   strategy:
     type: Recreate
-trustedProxies: ""
+trustedProxies: []
 ports:
 - name: boots-dhcp
   port: 67

--- a/tinkerbell/hegel/templates/deployment.yaml
+++ b/tinkerbell/hegel/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           {{- end }}
           env:
             - name: HEGEL_TRUSTED_PROXIES
-              value: {{ required "missing trustedProxies" .Values.trustedProxies | quote }}
+              value: {{ join "," .Values.trustedProxies }}
             {{- range $i, $env := .Values.env }}
             - name: {{ $env.name | quote }}
               value: {{ $env.value | quote }}

--- a/tinkerbell/hegel/values.yaml
+++ b/tinkerbell/hegel/values.yaml
@@ -1,5 +1,5 @@
 deploy: true
-trustedProxies: ""
+trustedProxies: []
 name: hegel
 image: quay.io/tinkerbell/hegel:v0.10.1
 imagePullPolicy: IfNotPresent

--- a/tinkerbell/stack/README.md
+++ b/tinkerbell/stack/README.md
@@ -7,7 +7,7 @@ This chart installs the full Tinkerbell stack.
 ```bash
 helm dependency build stack/
 trusted_proxies=$(kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}' | tr ' ' ',')
-helm install stack-release stack/ --create-namespace --namespace tink-system --wait --set "boots.trustedProxies=${trusted_proxies}" --set "hegel.trustedProxies=${trusted_proxies}"
+helm install stack-release stack/ --create-namespace --namespace tink-system --wait --set "boots.trustedProxies={${trusted_proxies}}" --set "hegel.trustedProxies={${trusted_proxies}}"
 ```
 
 ## Introduction
@@ -51,7 +51,7 @@ Now, deploy the chart.
 ```bash
 helm dependency build stack/
 trusted_proxies=$(kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}' | tr ' ' ',')
-helm install stack-release stack/ --create-namespace --namespace tink-system --wait --set "boots.trustedProxies=${trusted_proxies}" --set "hegel.trustedProxies=${trusted_proxies}"
+helm install stack-release stack/ --create-namespace --namespace tink-system --wait --set "boots.trustedProxies={${trusted_proxies}}" --set "hegel.trustedProxies={${trusted_proxies}}"
 ```
 
 These commands install the Tinkerbell Stack chart in the `tink-system` namespace with the release name of `stack-release`.


### PR DESCRIPTION
## Description

This PR uses array instead of string to manage trustedProxies.

## Why is this needed

Fixes: #29 

## How Has This Been Tested?

I managed to deploy the services using the charts without error. A comma-separated list of proxies appears using `kubectl get pods -o yaml -n tink-system <pod-name>`

```yaml
spec:
  containers:
  - args:
    - --backend=kubernetes
    - --http-port=50061
    env:
    - name: HEGEL_TRUSTED_PROXIES
      value: 10.244.3.0/24,10.244.2.0/24,10.244.5.0/24,10.244.0.0/24,10.244.1.0/24,10.244.4.0/24
    image: quay.io/tinkerbell/hegel:v0.10.1
```

## How are existing users impacted? What migration steps/scripts do we need?

N.A.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests (N.A.)
- [x] provided instructions on how to upgrade (N.A.)
