### PR TITLE
Refactor boots chart to expose configuration in a values native way

### DIFF
--- a/tinkerbell/boots/templates/_ports.tpl
+++ b/tinkerbell/boots/templates/_ports.tpl
@@ -1,0 +1,14 @@
+{{ define "boots.ports" }}
+- {{ .PortKey }}: {{ .http.port }}
+  name: {{ .http.name }}
+  protocol: TCP
+- {{ .PortKey }}: {{ .syslog.port }}
+  name: {{ .syslog.name }}
+  protocol: UDP
+- {{ .PortKey }}: {{ .dhcp.port }}
+  name: {{ .dhcp.name }}
+  protocol: UDP
+- {{ .PortKey }}: {{ .tftp.port }}
+  name: {{ .tftp.name }}
+  protocol: UDP
+{{- end }}

--- a/tinkerbell/boots/templates/deployment.yaml
+++ b/tinkerbell/boots/templates/deployment.yaml
@@ -1,10 +1,14 @@
 {{- if .Values.deploy }}
+{{- $remoteDhcpIp := default .Values.remoteIp .Values.remoteDhcpIp }}
+{{- $remoteSyslogIp := default .Values.remoteIp .Values.remoteSyslogIp }}
+{{- $osieBaseIp := default .Values.remoteIp .Values.osieBase.ip }}
+{{- $tinkServerIp := default .Values.remoteIp .Values.tinkServer.ip }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app: {{ .Values.name }}
-  name:  {{ .Values.name }}
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   replicas: {{ .Values.replicas }}
@@ -29,26 +33,43 @@ spec:
       containers:
         - image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- if .Values.args }}
-          args: 
-          {{- range .Values.args }}
+          args:
+            - -dhcp-addr={{ printf "%v:%v" .Values.dhcp.ip .Values.dhcp.port }}
+            - -ipxe-tftp-addr={{ printf "%v:%v" .Values.tftp.ip .Values.tftp.port }}
+            - -http-addr={{ printf "%v:%v" .Values.http.ip .Values.http.port }}
+            - -syslog-addr={{ printf "%v:%v" .Values.syslog.ip .Values.syslog.port }}
+            - -osie-path-override={{ printf "%v://%v:%v" .Values.osieBase.protocol $osieBaseIp .Values.osieBase.port }}
+          {{- range .Values.additionalArgs }}
             - {{ . }}
-          {{- end }}
           {{- end }}
           env:
             - name: TRUSTED_PROXIES
-              value: {{ required "missing trustedProxies" .Values.trustedProxies | quote }}
-            {{- range $i, $env := .Values.env }}
-            - name: {{ $env.name | quote }}
-              value: {{ $env.value | quote }}
+              value: {{ required "missing trustedProxies" ( join "," .Values.trustedProxies | quote ) }}
+            - name: DATA_MODEL_VERSION
+              value: "kubernetes"
+            - name: FACILITY_CODE
+              value: "lab1"
+            - name: MIRROR_BASE_URL
+              value: {{ printf "%v://%v:%v" .Values.osieBase.protocol $osieBaseIp .Values.osieBase.port | quote }}
+            - name: PUBLIC_IP
+              value: {{ $remoteDhcpIp | quote }}
+            - name: PUBLIC_SYSLOG_FQDN
+              value: {{ $remoteSyslogIp | quote }}
+            - name: TINKERBELL_GRPC_AUTHORITY
+              value: {{ printf "%s:%v" $tinkServerIp .Values.tinkServer.port | quote }}
+            - name: TINKERBELL_TLS
+              value: {{ .Values.tinkServer.tls | quote }}
+            - name: BOOTS_EXTRA_KERNEL_ARGS
+              value: {{ join " " ( append .Values.additionlKernelArgs ( printf "tink_worker_image=%s" ( required "missing tinkWorkerImage" .Values.tinkWorkerImage ) ) ) | quote }}
+            - name: BOOTS_LOG_LEVEL
+              value: {{ .Values.logLevel | quote }}
+            {{- range .Values.additionalEnv }}
+            - name: {{ .name | quote }}
+              value: {{ .value | quote }}
             {{- end }}
           {{- if not .Values.hostNetwork }}
           ports:
-            {{- range .Values.ports }}
-            - containerPort: {{ .targetPort }}
-              name: {{ .name }}
-              protocol: {{ .protocol }}
-            {{- end }}
+            {{- include "boots.ports" ( merge ( dict "PortKey" "containerPort" ) .Values  ) | indent 12 }}
           {{- end }}
           name: {{ .Values.name }}
           resources:

--- a/tinkerbell/boots/templates/service.yaml
+++ b/tinkerbell/boots/templates/service.yaml
@@ -9,12 +9,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  {{- range .Values.ports }}
-  - name: {{ .name }}
-    port: {{ .port }}
-    targetPort: {{ .targetPort }}
-    protocol: {{ .protocol }}
-  {{- end }}
+  {{- include "boots.ports" ( merge ( dict "PortKey" "port" ) .Values  ) | indent 2 }}
   selector:
     app: {{ .Values.name }}
 {{- end -}}

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -1,10 +1,17 @@
+# Toggle deployment of the service.
 deploy: true
-hostNetwork: true
+
+# Name of the service used as the deployment name and label selectors.
 name: boots
+
+# The image used to launch the container.
 image: quay.io/tinkerbell/boots:v0.8.0
 imagePullPolicy: IfNotPresent
+
+# The number of pods to run.
 replicas: 1
-args: ["-dhcp-addr=0.0.0.0:67"]
+
+# Resources bounds applied to the container.
 resources:
   limits:
     cpu: 500m
@@ -12,45 +19,97 @@ resources:
   requests:
     cpu: 10m
     memory: 64Mi
+
 roleName: boots-role
 roleBindingName: boots-rolebinding
+
 deployment:
   strategy:
     type: Recreate
-trustedProxies: ""
-ports:
-- name: boots-dhcp
+
+# The log level for the container.
+logLevel: "info"
+
+# The network mode to launch the boots container. When true, the boots container will use the
+# host network.
+hostNetwork: true
+
+# DHCP server configuration. Name is an identifier used across Kubernetes manifests for port
+# identification, ip is the IP address to bind to, and port is the port to bind to.
+dhcp:
+  name: boots-dhcp
+  ip: 0.0.0.0
   port: 67
-  protocol: UDP
-  targetPort: 67
-- name: boots-http
-  port: 80
-  protocol: TCP
-  targetPort: 80
-- name: boots-syslog
-  port: 514
-  protocol: UDP
-  targetPort: 514
-- name: boots-tftp
+
+# TFTP server configuration used to serve iPXE binaries. Name is an identifier used across
+# Kubernetes manifests for port identification, ip is the IP address to bind to, and port is the
+# port to bind to.
+tftp:
+  name: boots-tftp
+  ip: 0.0.0.0
   port: 69
-  protocol: UDP
-  targetPort: 69
-env:
-- name: DATA_MODEL_VERSION
-  value: "kubernetes"
-- name: FACILITY_CODE
-  value: "lab1"
-- name: HTTP_BIND
-  value: ":80"
-- name: MIRROR_BASE_URL
-  value: http://192.168.1.94:8080
-- name: PUBLIC_IP
-  value: 192.168.1.94
-- name: PUBLIC_SYSLOG_FQDN
-  value: 192.168.1.94
-- name: SYSLOG_BIND
-  value: 0.0.0.0:514
-- name: TINKERBELL_GRPC_AUTHORITY
-  value: 192.168.1.94:42113
-- name: TINKERBELL_TLS
-  value: "false"
+
+# HTTP server configuration used to serve iPXE scripts. Name is an identifier used across
+# Kubernetes manifests for port identification, ip is the IP address to bind to, and port is the
+# port to bind to.
+http:
+  name: boots-http
+  ip: 0.0.0.0
+  # -- WARNING: Customization of the HTTP port is not supported.
+  # -- See https://github.com/tinkerbell/boots/issues/317
+  port: 80
+
+# Syslog server configuration for the boots hosted syslog server. Name is an identifier used across
+# Kubernetes manifests for port identification, ip is the IP address to bind to, and port is the
+# port to bind to.
+syslog:
+  name: boots-syslog
+  ip: 0.0.0.0
+  port: 514
+
+# The default remote IP used for DHCP, TFTP, HTTP, Syslog, OSIE base URL, and Tink Server.
+# Each of these can be overridden individually below.
+remoteIp: 192.168.1.94
+
+# The DHCP address passed to the netboot client for retrieving DHCP configuration. Typically the
+# address of the boots DHCP server.
+remoteDhcpIp: ""
+
+# The Syslog address passed to the netboot client for retrieving logs. Typically the address
+# of the boots Syslog server.
+remoteSyslogIp: ""
+
+# Trusted proxies defines a list of IP or CIDR ranges that are allowed to set the X-Forwarded-For
+# header. This typically requires all Pod CIDRs in the cluster.
+trustedProxies: []
+
+# The base URL used to construct URLs for OSIE artifacts (typically Hook).
+osieBase:
+  protocol: http
+  ip: ""
+  port: 8080
+
+# The Tink Worker image passed to OSIE as a kernel arg for launching.
+tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.8.0
+
+# Tink Server configuration passed to the Tink Worker to establish a gRPC connection.
+tinkServer:
+  ip: ""
+  port: 42113
+  tls: false
+
+# Additional kernel arguments to pass to the OSIE.
+additionlKernelArgs: []
+
+# Additional arguments to pass to the boots container. Some arguments are already defined - refer
+# to the deployment.yaml template for details.
+additionalArgs: []
+
+# Additional environment variables to pass to the boots container. Each entry is expected to have a
+# name and value key. Some keys are already defined - refer to the deployment.yaml template for
+# details.
+#
+# Example
+#   - name: MY_ENV_VAR
+#     value: my-value
+additionalEnv: []

--- a/tinkerbell/stack/templates/nginx-configmap.yaml
+++ b/tinkerbell/stack/templates/nginx-configmap.yaml
@@ -16,14 +16,14 @@ data:
 
     http {
       server {
-        listen 80;
+        listen {{ .Values.boots.http.port }};
         location / {
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           resolver $POD_NAMESERVER;
           set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
 
-          proxy_pass http://$boots_dns;
+          proxy_pass http://$boots_dns:{{ .Values.boots.http.port }};
         }
       }
 
@@ -63,27 +63,27 @@ data:
       log_format logger-json escape=json '{"source": "nginx", "time": $msec, "address": "$remote_addr", "status": $status, "upstream_addr": "$upstream_addr"}';
 
       server {
-          listen 67 udp;
+          listen {{ .Values.boots.dhcp.port }} udp;
           resolver $POD_NAMESERVER; # needed in Kubernetes for dynamic DNS resolution
           set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
-          proxy_pass $boots_dns:67;
+          proxy_pass $boots_dns:{{ .Values.boots.dhcp.port }};
           proxy_bind $remote_addr:$remote_port transparent;
           proxy_responses 0;
           access_log /dev/stdout logger-json;
       }
       server {
-          listen 69 udp;
+          listen {{ .Values.boots.tftp.port }} udp;
           resolver $POD_NAMESERVER;
           set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
-          proxy_pass $boots_dns:69;
+          proxy_pass $boots_dns:{{ .Values.boots.tftp.port }};
           proxy_timeout 1s;
           access_log /dev/stdout logger-json;
       }
       server {
-          listen 514 udp;
+          listen {{ .Values.boots.syslog.port }} udp;
           resolver $POD_NAMESERVER;
           set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
-          proxy_pass $boots_dns:514;
+          proxy_pass $boots_dns:{{ .Values.boots.syslog.port }};
           proxy_bind $remote_addr:$remote_port transparent;
           proxy_responses 0;
           access_log /dev/stdout logger-json;

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -29,10 +29,8 @@ spec:
           envsubst '$POD_NAMESERVER' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf;
           nginx -g 'daemon off;'
         ports:
-        {{- range .Values.boots.ports }}
-        - containerPort: {{ .port}}
-          name: {{ .name }}
-          protocol: {{ .protocol }}
+        {{- if not .Values.boots.hostNetwork }}
+        {{- include "boots.ports" ( merge ( dict "PortKey" "containerPort" ) .Values.boots  ) | indent 8 }}
         {{- end }}
         - containerPort: {{ .Values.hegel.deployment.port }}
           protocol: TCP
@@ -114,22 +112,14 @@ spec:
   - name: {{ .Values.hegel.name }}
     port: {{ .Values.hegel.deployment.port }}
     protocol: TCP
-    targetPort: {{ .Values.hegel.deployment.portName }}
   - name: {{ .Values.tink.server.name }}
     port: {{ .Values.tink.server.deployment.port }}
     protocol: TCP
-    targetPort: {{ .Values.tink.server.deployment.portName }}
   - name: {{ .Values.stack.hook.name }}
     port: {{ .Values.stack.hook.port }}
     protocol: TCP
-    targetPort: hook-http
   {{- if not .Values.boots.hostNetwork }}
-  {{- range .Values.boots.ports }}
-  - name: {{ .name }}
-    port: {{ .port }}
-    targetPort: {{ .targetPort }}
-    protocol: {{ .protocol }}
-  {{- end }}
+  {{- include "boots.ports" ( merge ( dict "PortKey" "port" ) .Values.boots  ) | indent 2 }}
   {{- end }}
   selector:
     app: stack

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -29,46 +29,29 @@ stack:
     imagePullPolicy: IfNotPresent
     roleName: kube-vip-role
     roleBindingName: kube-vip-rolebinding
+    # Customize the interface KubeVIP advertises on. When unset, KubeVIP will autodetect the
+    # interface.
+    #interface: eth0
 
-# boots chart overrides
+# -- Overrides
+# The values defined here override those in the individual charts. Some of them require tweaking
+# before deployment as they are environment dependent; others are surfaced for convenience.
+#
+# See individual chart documentation for additional detail.
+
 boots:
   image: quay.io/tinkerbell/boots:v0.8.0
-  env:
-    - name: DATA_MODEL_VERSION
-      value: "kubernetes"
-    - name: FACILITY_CODE
-      value: "lab1"
-    - name: HTTP_BIND
-      value: ":80"
-    - name: MIRROR_BASE_URL
-      value: http://192.168.2.111:8080
-    - name: BOOTS_OSIE_PATH_OVERRIDE
-      value: http://192.168.2.111:8080
-    - name: PUBLIC_IP
-      value: 192.168.2.111
-    - name: PUBLIC_SYSLOG_FQDN
-      value: 192.168.2.111
-    - name: SYSLOG_BIND
-      value: :514
-    - name: TINKERBELL_GRPC_AUTHORITY
-      value: 192.168.2.111:42113
-    - name: TINKERBELL_TLS
-      value: "false"
-    - name: BOOTS_LOG_LEVEL
-      value: "debug"
-    - name: BOOTS_EXTRA_KERNEL_ARGS
-      value: "tink_worker_image=quay.io/tinkerbell/tink-worker:v0.8.0"
-  hostNetwork: true
+  tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.8.0
+  trustedProxies: []
+  remoteIp: 192.168.1.94
 
-# hegel chart overrides
 hegel:
   image: quay.io/tinkerbell/hegel:v0.10.1
+  trustedProxies: []
 
-# rufio chart overrides
 rufio:
   image: quay.io/tinkerbell/rufio:v0.1.0
 
-# tink chart overrides
 tink:
   controller:
     image: quay.io/tinkerbell/tink-controller:v0.8.0


### PR DESCRIPTION
Refactor the boots chart to provide a foundation for values native mechanisms to configure Boots and other charts. This alleviates a number of issues:

- Can configure trusted proxies in Boots using `--set` and `{}` syntax. 
- No longer need to include all args/envs when wanting to override individual pieces of configuration.