### PR TITLE
Add NodePort support to tink-stack

### DIFF
--- a/tinkerbell/boots/templates/_ports.tpl
+++ b/tinkerbell/boots/templates/_ports.tpl
@@ -2,13 +2,25 @@
 - {{ .PortKey }}: {{ .http.port }}
   name: {{ .http.name }}
   protocol: TCP
+  {{- if eq .ServiceType "NodePort" }}
+  nodePort: {{ .http.nodePort }}
+  {{- end }}
 - {{ .PortKey }}: {{ .syslog.port }}
   name: {{ .syslog.name }}
   protocol: UDP
+  {{- if eq .ServiceType "NodePort" }}
+  nodePort: {{ .syslog.nodePort }}
+  {{- end }}
 - {{ .PortKey }}: {{ .dhcp.port }}
   name: {{ .dhcp.name }}
   protocol: UDP
+  {{- if eq .ServiceType "NodePort" }}
+  nodePort: {{ .dhcp.nodePort }}
+  {{- end }}
 - {{ .PortKey }}: {{ .tftp.port }}
   name: {{ .tftp.name }}
   protocol: UDP
+  {{- if eq .ServiceType "NodePort" }}
+  nodePort: {{ .tftp.nodePort }}
+  {{- end }}
 {{- end }}

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -40,6 +40,7 @@ dhcp:
   name: boots-dhcp
   ip: 0.0.0.0
   port: 67
+  nodePort: 30067
 
 # TFTP server configuration used to serve iPXE binaries. Name is an identifier used across
 # Kubernetes manifests for port identification, ip is the IP address to bind to, and port is the
@@ -48,6 +49,7 @@ tftp:
   name: boots-tftp
   ip: 0.0.0.0
   port: 69
+  nodePort: 30069
 
 # HTTP server configuration used to serve iPXE scripts. Name is an identifier used across
 # Kubernetes manifests for port identification, ip is the IP address to bind to, and port is the
@@ -58,6 +60,7 @@ http:
   # -- WARNING: Customization of the HTTP port is not supported.
   # -- See https://github.com/tinkerbell/boots/issues/317
   port: 80
+  nodePort: 30080
 
 # Syslog server configuration for the boots hosted syslog server. Name is an identifier used across
 # Kubernetes manifests for port identification, ip is the IP address to bind to, and port is the
@@ -66,6 +69,7 @@ syslog:
   name: boots-syslog
   ip: 0.0.0.0
   port: 514
+  nodePort: 30514
 
 # The default remote IP used for DHCP, TFTP, HTTP, Syslog, OSIE base URL, and Tink Server.
 # Each of these can be overridden individually below.

--- a/tinkerbell/hegel/values.yaml
+++ b/tinkerbell/hegel/values.yaml
@@ -8,6 +8,7 @@ service:
 deployment:
   port: 50061
   portName: hegel-http
+  nodePort: 30061
 resources:
   limits:
     cpu: 500m

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -112,14 +112,23 @@ spec:
   - name: {{ .Values.hegel.name }}
     port: {{ .Values.hegel.deployment.port }}
     protocol: TCP
+    {{- if eq .Values.stack.service.type "NodePort" }}
+    nodePort: {{ .Values.hegel.deployment.nodePort }}
+    {{- end }}
   - name: {{ .Values.tink.server.name }}
     port: {{ .Values.tink.server.deployment.port }}
     protocol: TCP
+    {{- if eq .Values.stack.service.type "NodePort" }}
+    nodePort: {{ .Values.tink.server.deployment.nodePort }}
+    {{- end }}
   - name: {{ .Values.stack.hook.name }}
     port: {{ .Values.stack.hook.port }}
     protocol: TCP
+    {{- if eq .Values.stack.service.type "NodePort" }}
+    nodePort: {{ .Values.stack.hook.nodePort }}
+    {{- end }}
   {{- if not .Values.boots.hostNetwork }}
-  {{- include "boots.ports" ( merge ( dict "PortKey" "port" ) .Values.boots  ) | indent 2 }}
+  {{- include "boots.ports" ( merge ( dict "PortKey" "port" "ServiceType" .Values.stack.service.type) .Values.boots  ) | indent 2 }}
   {{- end }}
   selector:
     app: stack

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -12,6 +12,7 @@ stack:
     enabled: true
     name: hook-files
     port: 8080
+    nodePort: 31080
     image: alpine
     downloads:
       - url: https://github.com/tinkerbell/hook/releases/download/v0.7.0/hook_x86_64.tar.gz

--- a/tinkerbell/tink/values.yaml
+++ b/tinkerbell/tink/values.yaml
@@ -28,6 +28,7 @@ server:
   deployment:
     port: 42113
     portName: tink-grpc
+    nodePort: 32113
   args: ["--tls=false"]
   resources:
     limits:


### PR DESCRIPTION
## Description

Right now, the tink-stack service works when its type is set to LoadBalancer. This patch makes it also workable when set as a NodePort service. One slightly annoying aspect of NodePort services is that they can only work with ports between 30000 and 32768. I thus somewhat arbitrarily picked values in that range.

## Why is this needed

This allows running tinkebell without a load balancer, for instance within a simple kind cluster. It sets all the node ports to predictable values so that appropriate port forwarding can be established. If nodePort values were not set, kubernetes would randomly assign them, requiring some runtime detection to learn the mappings.

As an example, this kind configuration maps some of the node ports set within the local cluster to the intended ports on the host system:

```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  extraPortMappings:
  - containerPort: 30061
    hostPort: 50061
  - containerPort: 32113
    hostPort: 42113
  - containerPort: 31080
    hostPort: 8080
  - containerPort: 30080
    hostPort: 80
```

## How are existing users impacted? What migration steps/scripts do we need?

No impact expected. Even if anyone was already using the service configured as NodePort, the fixed ports should work just as well as the random ports that get set now.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
