### PR TITLE
Use a list for Hegel trusted proxy configuration

### DIFF
--- a/tinkerbell/hegel/templates/deployment.yaml
+++ b/tinkerbell/hegel/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           {{- end }}
           env:
             - name: HEGEL_TRUSTED_PROXIES
-              value: {{ required "missing trustedProxies" .Values.trustedProxies | quote }}
+              value: {{ required "missing trustedProxies" ( join "," .Values.trustedProxies | quote ) }}
             {{- range $i, $env := .Values.env }}
             - name: {{ $env.name | quote }}
               value: {{ $env.value | quote }}

--- a/tinkerbell/hegel/values.yaml
+++ b/tinkerbell/hegel/values.yaml
@@ -1,5 +1,4 @@
 deploy: true
-trustedProxies: ""
 name: hegel
 image: quay.io/tinkerbell/hegel:v0.10.1
 imagePullPolicy: IfNotPresent
@@ -18,3 +17,7 @@ resources:
     memory: 64Mi
 roleName: hegel-role
 roleBindingName: hegel-rolebinding
+
+# Trusted proxies defines a list of IP or CIDR ranges that are allowed to set the X-Forwarded-For
+# header. This typically requires all Pod CIDRs in the cluster.
+trustedProxies: []


### PR DESCRIPTION
We found a pattern that works well and is proven out in Boots. This aligns trusted proxy configuration with the approach in Hegel.

Closes #29 