### PR TITLE
Set stack.loadBalancerIP equal to boots.remoteIp:

### DIFF
--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -43,7 +43,8 @@ boots:
   image: quay.io/tinkerbell/boots:v0.8.0
   tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.8.0
   trustedProxies: []
-  remoteIp: 192.168.1.94
+  # In most cases this value will be the same as `stack.loadBalancerIP`.
+  remoteIp: 192.168.2.111
 
 hegel:
   image: quay.io/tinkerbell/hegel:v0.10.1


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
In most cases these will need to be the same so that files like the Hook kernel and initramfs will be served from the correct IP.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
