### PR TITLE
Allow for running the stack nginx on hostNetwork:

### DIFF
--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -20,6 +20,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if eq .Values.stack.service.enabled false }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       containers:
       - name: {{ .Values.stack.name }}
         image: {{ .Values.stack.image }}
@@ -91,6 +95,7 @@ spec:
             - key: nginx.conf
               path: nginx.conf.template
 ---
+{{- if .Values.stack.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -118,12 +123,11 @@ spec:
   - name: {{ .Values.stack.hook.name }}
     port: {{ .Values.stack.hook.port }}
     protocol: TCP
-  {{- if not .Values.boots.hostNetwork }}
   {{- include "boots.ports" ( merge ( dict "PortKey" "port" ) .Values.boots  ) | indent 2 }}
-  {{- end }}
   selector:
     app: stack
     {{- with .Values.stack.selector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end -}}
 {{- end -}}

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -2,6 +2,7 @@ stack:
   enabled: true
   name: tink-stack
   service:
+    enabled: true
     type: LoadBalancer
   selector:
     app: tink-stack


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This enables running the stack in constrained
environments like with Kubernetes KinD. Only
the stack chart is modified. All service ports
listen on are their known/normal ones.
I.E. 50061, 42113, 8080, 80, 69, 67, 514

To enable this the following would be set in `stack/values.yaml`

```yaml
stack.service.enabled: false
boots.hostNetwork: false
```

Here's an example KinD config file that would work with this.
```yaml

kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  extraPortMappings:
  - containerPort: 50061
    hostPort: 50061
  - containerPort: 42113
    hostPort: 42113
  - containerPort: 8080
    hostPort: 8080
  - containerPort: 80
    hostPort: 80
  - containerPort: 69
    hostPort: 69
    protocol: udp
  - containerPort: 67
    hostPort: 67
    protocol: udp
  - containerPort: 514
    hostPort: 514
    protocol: udp
```

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
