### PR TITLE
Add relay functionality:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,4 +16,5 @@ jobs:
           version: v3.9.4
 
       - name: Helm lint
+        # run `helm dependency update tinkerbell/stack`` if this fails
         run: helm dependency build tinkerbell/stack/ && helm lint tinkerbell/{boots,hegel,stack,tink}

--- a/tinkerbell/boots/Chart.yaml
+++ b/tinkerbell/boots/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/boots/templates/service.yaml
+++ b/tinkerbell/boots/templates/service.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.deploy -}}
+{{- if and .Values.deploy .Values.service.enabled -}}
+{{- $loadBalancerIP := default .Values.remoteIp .Values.service.loadBalancerIP }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,6 +8,12 @@ metadata:
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerClass: {{ .Values.service.class }}
+  loadBalancerIP: {{ $loadBalancerIP }}
+  {{- end }}
+  externalTrafficPolicy: Local
   ports:
   {{- include "boots.ports" ( merge ( dict "PortKey" "port" ) .Values  ) | indent 2 }}
   selector:

--- a/tinkerbell/boots/templates/service.yaml
+++ b/tinkerbell/boots/templates/service.yaml
@@ -7,7 +7,6 @@ metadata:
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  clusterIP: None
   ports:
   {{- include "boots.ports" ( merge ( dict "PortKey" "port" ) .Values  ) | indent 2 }}
   selector:

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -25,14 +25,14 @@ roleBindingName: boots-rolebinding
 
 deployment:
   strategy:
-    type: Recreate
+    type: RollingUpdate
 
 # The log level for the container.
 logLevel: "info"
 
 # The network mode to launch the boots container. When true, the boots container will use the
 # host network.
-hostNetwork: true
+hostNetwork: false
 
 # DHCP server configuration. Name is an identifier used across Kubernetes manifests for port
 # identification, ip is the IP address to bind to, and port is the port to bind to.

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -27,6 +27,12 @@ deployment:
   strategy:
     type: RollingUpdate
 
+service:
+  enabled: true
+  type: LoadBalancer
+  class: kube-vip.io/kube-vip-class
+  loadBalancerIP: ""
+
 # The log level for the container.
 logLevel: "info"
 

--- a/tinkerbell/hegel/Chart.yaml
+++ b/tinkerbell/hegel/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/hegel/templates/service.yaml
+++ b/tinkerbell/hegel/templates/service.yaml
@@ -7,7 +7,6 @@ metadata:
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  clusterIP: None
   ports:
   - port: {{ .Values.service.port }}
     protocol: TCP

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: tink
   repository: file://../tink
-  version: 0.2.0
+  version: 0.2.1
 - name: boots
   repository: file://../boots
-  version: 0.2.0
+  version: 0.2.1
 - name: rufio
   repository: file://../rufio
   version: 0.2.3
 - name: hegel
   repository: file://../hegel
-  version: 0.3.0
-digest: sha256:ddb8f3784b830a75e28ec62f105b01836846de478c292ac5a5df86a8204585dc
-generated: "2023-02-16T09:15:54.932213-06:00"
+  version: 0.3.1
+digest: sha256:38c51531d71414a28b0cf0f0fb2a0d90ef79c59d022f2bb77bd65e1f5d3c72bd
+generated: "2023-02-11T23:29:04.146691294-07:00"

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: hegel
   repository: file://../hegel
   version: 0.3.1
-digest: sha256:38c51531d71414a28b0cf0f0fb2a0d90ef79c59d022f2bb77bd65e1f5d3c72bd
-generated: "2023-02-11T23:29:04.146691294-07:00"
+digest: sha256:2f9da61090928e4b22b1e95bda787b67955ccd711f95cc71bc9f256fc6446531
+generated: "2023-02-24T14:30:19.632765086-07:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -15,24 +15,24 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.0"
+appVersion: "0.3.0"
 
 dependencies:
   - name: tink
-    version: "0.2.0"
+    version: "0.2.1"
     repository: "file://../tink"
   - name: boots
-    version: "0.2.0"
+    version: "0.2.1"
     repository: "file://../boots"
   - name: rufio
     version: "0.2.3"
     repository: "file://../rufio"
   - name: hegel
-    version: "0.3.0"
+    version: "0.3.1"
     repository: "file://../hegel"

--- a/tinkerbell/stack/README.md
+++ b/tinkerbell/stack/README.md
@@ -91,6 +91,16 @@ helm uninstall stack-release --namespace tink-system
 | `kubevip.roleBindingName` | Role binding name to use for the kube-vip load service | `kube-vip-rolebinding` |
 | `kubevip.interface` | Interface to use for advertizing the load balancer IP. Leaving it unset to allow Kubevip to auto discover the interface to use. | `""` |
 
+### DHCP Relay Parameters
+
+| Name | Description | Value |
+| ---- | ----------- | ----- |
+| `stack.relay.name` | Name for the relay service | `dhcp-relay` |
+| `stack.relay.enabled` | Enable the deployment of the DHCP relay service | `true` |
+| `stack.relay.image` | Image to use for the DHCP relay service | `ghcr.io/jacobweinstock/dhcrelay` |
+| `stack.relay.maxHopCount` | Maximum number of hops to allow for DHCP relay | `10` |
+| `stack.relay.sourceInterface` | Host/Node interface to use for listening for DHCP broadcast packets | `eno1` |
+
 ### Tinkerbell Services Parameters
 
 All dependent services(Boots, Hegel, Rufio, Tink) can have their values overridden here. The following format is used to accomplish this.

--- a/tinkerbell/stack/templates/kubevip.yaml
+++ b/tinkerbell/stack/templates/kubevip.yaml
@@ -21,11 +21,11 @@ spec:
         env:
         - name: vip_arp
           value: "true"
-        - name: vip_cidr
-          value: "32"
         - name: svc_enable
           value: "true"
         - name: svc_election
+          value: "true"
+        - name: enableServicesElection
           value: "true"
         {{- with .Values.stack.kubevip.interface }}
         - name: vip_interface

--- a/tinkerbell/stack/templates/nginx-configmap.yaml
+++ b/tinkerbell/stack/templates/nginx-configmap.yaml
@@ -16,18 +16,6 @@ data:
 
     http {
       server {
-        listen {{ .Values.boots.http.port }};
-        location / {
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          resolver $POD_NAMESERVER;
-          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
-
-          proxy_pass http://$boots_dns:{{ .Values.boots.http.port }};
-        }
-      }
-
-      server {
         listen {{ .Values.hegel.deployment.port }};
         location / {
           proxy_set_header X-Real-IP $remote_addr;
@@ -56,37 +44,6 @@ data:
         location / {
           root /usr/share/nginx/html;
         }
-      }
-    }
-
-    stream {
-      log_format logger-json escape=json '{"source": "nginx", "time": $msec, "address": "$remote_addr", "status": $status, "upstream_addr": "$upstream_addr"}';
-
-      server {
-          listen {{ .Values.boots.dhcp.port }} udp;
-          resolver $POD_NAMESERVER; # needed in Kubernetes for dynamic DNS resolution
-          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
-          proxy_pass $boots_dns:{{ .Values.boots.dhcp.port }};
-          proxy_bind $remote_addr:$remote_port transparent;
-          proxy_responses 0;
-          access_log /dev/stdout logger-json;
-      }
-      server {
-          listen {{ .Values.boots.tftp.port }} udp;
-          resolver $POD_NAMESERVER;
-          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
-          proxy_pass $boots_dns:{{ .Values.boots.tftp.port }};
-          proxy_timeout 1s;
-          access_log /dev/stdout logger-json;
-      }
-      server {
-          listen {{ .Values.boots.syslog.port }} udp;
-          resolver $POD_NAMESERVER;
-          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
-          proxy_pass $boots_dns:{{ .Values.boots.syslog.port }};
-          proxy_bind $remote_addr:$remote_port transparent;
-          proxy_responses 0;
-          access_log /dev/stdout logger-json;
       }
     }
 {{- end }}

--- a/tinkerbell/stack/templates/nginx-configmap.yaml
+++ b/tinkerbell/stack/templates/nginx-configmap.yaml
@@ -21,7 +21,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           resolver $POD_NAMESERVER;
-          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
+          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
 
           proxy_pass http://$boots_dns:{{ .Values.boots.http.port }};
         }
@@ -33,7 +33,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           resolver $POD_NAMESERVER;
-          set $hegel_dns {{ .Values.hegel.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
+          set $hegel_dns {{ .Values.hegel.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
 
           proxy_pass http://$hegel_dns:{{ .Values.hegel.deployment.port }};
         }
@@ -45,7 +45,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           resolver $POD_NAMESERVER;
-          set $tink_dns {{ .Values.tink.server.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
+          set $tink_dns {{ .Values.tink.server.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
 
           grpc_pass grpc://$tink_dns:{{ .Values.tink.server.deployment.port }};
         }
@@ -65,7 +65,7 @@ data:
       server {
           listen {{ .Values.boots.dhcp.port }} udp;
           resolver $POD_NAMESERVER; # needed in Kubernetes for dynamic DNS resolution
-          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
+          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
           proxy_pass $boots_dns:{{ .Values.boots.dhcp.port }};
           proxy_bind $remote_addr:$remote_port transparent;
           proxy_responses 0;
@@ -74,7 +74,7 @@ data:
       server {
           listen {{ .Values.boots.tftp.port }} udp;
           resolver $POD_NAMESERVER;
-          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
+          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
           proxy_pass $boots_dns:{{ .Values.boots.tftp.port }};
           proxy_timeout 1s;
           access_log /dev/stdout logger-json;
@@ -82,7 +82,7 @@ data:
       server {
           listen {{ .Values.boots.syslog.port }} udp;
           resolver $POD_NAMESERVER;
-          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local; # needed in Kubernetes for dynamic DNS resolution
+          set $boots_dns {{ .Values.boots.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
           proxy_pass $boots_dns:{{ .Values.boots.syslog.port }};
           proxy_bind $remote_addr:$remote_port transparent;
           proxy_responses 0;

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -62,7 +62,7 @@ spec:
       initContainers:
       - name: init-hook-download
         image: {{ .Values.stack.hook.image }}
-        command: ["/bin/sh", "-xc"]
+        command: ["/bin/sh", "-xec"]
         args: # TODO(jacobweinstock): add checksum verification after download
         - rm -rf /usr/share/nginx/html/checksums.txt;
           touch /usr/share/nginx/html/checksums.txt;
@@ -73,8 +73,8 @@ spec:
           cd /usr/share/nginx/html/;
           sha512sum -c checksums.txt && exit 0;
           {{- range $index, $keys := .Values.stack.hook.downloads }}
-          apk add wget;
           echo downloading HOOK...;
+          apt-get update && apt-get install -y wget;
           wget -O /tmp/hook{{ $index }}.tar.gz {{ $keys.url }};
           tar -zxvf /tmp/hook{{ $index }}.tar.gz -C "/usr/share/nginx/html/";
           rm -rf /tmp/hook{{ $index }}.tar.gz;
@@ -99,9 +99,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    "helm.sh/hook": "post-install,post-delete,post-rollback,post-upgrade"
-    "helm.sh/hook-weight": "5"
   labels:
     app: {{ .Values.stack.name }}
   name: {{ .Values.stack.name }}

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.stack.enabled -}}
+{{- if .Values.stack.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,7 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if eq .Values.stack.service.enabled false }}
+      {{- if not .Values.stack.service.enabled }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
@@ -33,9 +33,6 @@ spec:
           envsubst '$POD_NAMESERVER' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf;
           nginx -g 'daemon off;'
         ports:
-        {{- if not .Values.boots.hostNetwork }}
-        {{- include "boots.ports" ( merge ( dict "PortKey" "containerPort" ) .Values.boots  ) | indent 8 }}
-        {{- end }}
         - containerPort: {{ .Values.hegel.deployment.port }}
           protocol: TCP
           name: {{ .Values.hegel.deployment.portName }}
@@ -94,7 +91,7 @@ spec:
           items:
             - key: nginx.conf
               path: nginx.conf.template
-{{- if .Values.stack.service.enabled -}}
+{{- if .Values.stack.service.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -120,11 +117,10 @@ spec:
   - name: {{ .Values.stack.hook.name }}
     port: {{ .Values.stack.hook.port }}
     protocol: TCP
-  {{- include "boots.ports" ( merge ( dict "PortKey" "port" ) .Values.boots  ) | indent 2 }}
   selector:
     app: stack
     {{- with .Values.stack.selector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -94,8 +94,8 @@ spec:
           items:
             - key: nginx.conf
               path: nginx.conf.template
+{{- if .Values.stack.service.enabled -}}
 ---
-{{- if .Values.stack.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/tinkerbell/stack/templates/relay.yaml
+++ b/tinkerbell/stack/templates/relay.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.stack.enabled .Values.stack.relay.enabled -}}
+---
+{{- $sourceInterface := ( required "sourceInterface must be specified" .Values.stack.relay.sourceInterface ) }}
+{{- $macvlanInterfaceName := printf "%s%s" "macvlan" (randNumeric 2) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.stack.name}}-relay
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.stack.name }}-relay
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.stack.name }}-relay
+    spec:
+      containers:
+      - name: {{ .Values.stack.name }}-relay
+        image: {{ .Values.stack.relay.image }}
+        args: ["-m", "append", "-c", "{{ .Values.stack.relay.maxHopCount }}", "-id", "{{ $macvlanInterfaceName }}", "-iu", "eth0", "-U", "eth0", "boots.{{ .Release.Namespace }}.svc.cluster.local."]
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      hostPID: true
+      initContainers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              # TODO: make this more resilient so that if the interface name is already taken we handle it, of if any commands fail after
+              # the interface is created we clean up the interface
+              # Create a macvlan interface
+              nsenter -t1 -n ip link add {{ $macvlanInterfaceName }} link {{ $sourceInterface }} type macvlan mode bridge
+              # Move the interface into the POD
+              pid=$(echo $$)
+              nsenter -t1 -n ip link set {{ $macvlanInterfaceName }} netns ${pid}
+              # Set the macvlan interface up
+              ip link set {{ $macvlanInterfaceName }} up
+              # Set the IP address
+              ip addr add {{ .Values.stack.relay.sourceIP }} dev {{ $macvlanInterfaceName }}
+          image: alpine
+          name: macvlan-interface
+          securityContext:
+            privileged: true
+{{- end -}}

--- a/tinkerbell/stack/templates/relay.yaml
+++ b/tinkerbell/stack/templates/relay.yaml
@@ -9,17 +9,17 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Values.stack.name }}-relay
+      app: {{ .Values.stack.relay.name }}
   replicas: 1
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: {{ .Values.stack.name }}-relay
+        app: {{ .Values.stack.relay.name }}
     spec:
       containers:
-      - name: {{ .Values.stack.name }}-relay
+      - name: {{ .Values.stack.relay.name }}
         image: {{ .Values.stack.relay.image }}
         args: ["-m", "append", "-c", "{{ .Values.stack.relay.maxHopCount }}", "-id", "{{ $macvlanInterfaceName }}", "-iu", "eth0", "-U", "eth0", "boots.{{ .Release.Namespace }}.svc.cluster.local."]
         resources:
@@ -29,26 +29,31 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        securityContext:
+          capabilities:
+            add:
+              - NET_RAW
       hostPID: true
       initContainers:
-        - command:
-            - /bin/sh
-            - -c
-            - |
-              set -e
-              # TODO: make this more resilient so that if the interface name is already taken we handle it, of if any commands fail after
-              # the interface is created we clean up the interface
-              # Create a macvlan interface
-              nsenter -t1 -n ip link add {{ $macvlanInterfaceName }} link {{ $sourceInterface }} type macvlan mode bridge
-              # Move the interface into the POD
-              pid=$(echo $$)
-              nsenter -t1 -n ip link set {{ $macvlanInterfaceName }} netns ${pid}
-              # Set the macvlan interface up
-              ip link set {{ $macvlanInterfaceName }} up
-              # Set the IP address
-              ip addr add {{ .Values.stack.relay.sourceIP }} dev {{ $macvlanInterfaceName }}
-          image: alpine
-          name: macvlan-interface
-          securityContext:
-            privileged: true
-{{- end -}}
+      - command:
+          - /bin/sh
+          - -c
+          - |
+            # This script allows us to listen and respond to DHCP requests on a host network interface and interact with Boots properly.
+            # This is used instead of `hostNetwork: true` because the dhcp relay requires clear paths for listening for broadcast traffic
+            # and sending/receiving unicast traffic to/from Boots.
+            set -xe
+            # Create a macvlan interface. TODO: If this fails, try again with a different name?
+            nsenter -t1 -n ip link add {{ $macvlanInterfaceName }} link {{ $sourceInterface }} type macvlan mode bridge
+            # Move the interface into the POD.
+            pid=$(echo $$)
+            nsenter -t1 -n ip link set {{ $macvlanInterfaceName }} netns ${pid} || nsenter -t1 -n ip link delete {{ $macvlanInterfaceName }}
+            # Set the macvlan interface up
+            ip link set {{ $macvlanInterfaceName }} up
+            # Set the IP address
+            ip addr add {{ .Values.stack.loadBalancerIP }}/32 dev {{ $macvlanInterfaceName }} noprefixroute
+        image: alpine
+        name: macvlan-interface
+        securityContext:
+          privileged: true
+{{- end }}

--- a/tinkerbell/stack/templates/relay.yaml
+++ b/tinkerbell/stack/templates/relay.yaml
@@ -1,5 +1,4 @@
 {{- if and .Values.stack.enabled .Values.stack.relay.enabled -}}
----
 {{- $sourceInterface := ( required "sourceInterface must be specified" .Values.stack.relay.sourceInterface ) }}
 {{- $macvlanInterfaceName := printf "%s%s" "macvlan" (randNumeric 2) -}}
 apiVersion: apps/v1

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -6,7 +6,7 @@ stack:
     type: LoadBalancer
   selector:
     app: tink-stack
-  loadBalancerIP: 192.168.2.111
+  loadBalancerIP: 192.168.2.112
   lbClass: kube-vip.io/kube-vip-class
   image: nginx:1.23.1
   hook:
@@ -15,10 +15,10 @@ stack:
     port: 8080
     image: ubuntu
     downloads:
-      - url: https://github.com/tinkerbell/hook/releases/download/v0.7.0/hook_x86_64.tar.gz
+      - url: https://github.com/tinkerbell/hook/releases/download/latest/hook_x86_64.tar.gz
         sha512sum:
-          kernel: "7c35042d35c003ae1f424e503ad6edf21854bc70b24b37006e810c3c8a92543420eed129c14e364769b0f32c27bdf4c61299fce8f8156af7477cac6a43931a20  vmlinuz-x86_64"
-          initramfs: "be7c3d57e2d73bfa4e41a2b5740c722b1c83722e4388b3cff9017192fce43ede360221e3095c800e511d7b4bce6065f2906883421409dd6d983412418a8d903e  initramfs-x86_64"
+          kernel: "45a83dc747ff05fda09dc7a3b376fca3d82079fbfe99927d9f1c935f2070b5ac6469a41387fefd9e2eeb51062959846900583274a5d02e4131f37162a6167b28  vmlinuz-x86_64"
+          initramfs: "93117aa2a7b4c1eabf95bc4582a41ea7e896b3a871bdf8e3048c5dba42558add6520989f507aeb245ac7ad929b408eba2b4f7af87afd0c888645e9fa1afa4327  initramfs-x86_64"
       - url: https://github.com/tinkerbell/hook/releases/download/v0.7.0/hook_aarch64.tar.gz
         sha512sum:
           kernel: "2f1bdbf64380e281288f54c6ddd29221d8a007d29b40f405da0592ed32ef6e52695fc5071e05b2db3f075122943d62a2c266704d154a16ffb7b278c70538e7da  vmlinuz-aarch64"
@@ -32,14 +32,14 @@ stack:
     roleBindingName: kube-vip-rolebinding
     # Customize the interface KubeVIP advertises on. When unset, KubeVIP will autodetect the
     # interface.
-    #interface: eth0
+    #interface: enp0s8
   relay:
+    name: dhcp-relay
     enabled: true
     image: ghcr.io/jacobweinstock/dhcrelay
     maxHopCount: 10
     # sourceInterface is the host/node interface to listen on for DHCP broadcast packets.
-    sourceInterface: eno1
-    sourceIP: 192.168.2.63/24
+    sourceInterface: eno1 # TODO(jacobweinstock): investigate autodetecting a default
 
 # -- Overrides
 # The values defined here override those in the individual charts. Some of them require tweaking
@@ -51,8 +51,15 @@ boots:
   image: quay.io/tinkerbell/boots:v0.8.0
   tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.8.0
   trustedProxies: []
-  # In most cases this value will be the same as `stack.loadBalancerIP`.
-  remoteIp: 192.168.2.111
+  # This will be the IP address that machines use to reach Boots for netbooting. It should be a unused IP address in your network.
+  remoteIp: 192.168.2.113
+  # Once the Kubernetes Gateway API is more stable, we will use that and be able to require only a single IP for all Tinkerbell services.
+  tinkServer:
+    # This should be the same as `stack.loadBalancerIP`.
+    ip: 192.168.2.112
+  osieBase:
+    # This should be the same as `stack.loadBalancerIP`.
+    ip: 192.168.2.112
 
 hegel:
   image: quay.io/tinkerbell/hegel:v0.10.1

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -15,10 +15,10 @@ stack:
     port: 8080
     image: ubuntu
     downloads:
-      - url: https://github.com/tinkerbell/hook/releases/download/latest/hook_x86_64.tar.gz
+      - url: https://github.com/tinkerbell/hook/releases/download/v0.7.0/hook_x86_64.tar.gz
         sha512sum:
-          kernel: "45a83dc747ff05fda09dc7a3b376fca3d82079fbfe99927d9f1c935f2070b5ac6469a41387fefd9e2eeb51062959846900583274a5d02e4131f37162a6167b28  vmlinuz-x86_64"
-          initramfs: "93117aa2a7b4c1eabf95bc4582a41ea7e896b3a871bdf8e3048c5dba42558add6520989f507aeb245ac7ad929b408eba2b4f7af87afd0c888645e9fa1afa4327  initramfs-x86_64"
+          kernel: "7c35042d35c003ae1f424e503ad6edf21854bc70b24b37006e810c3c8a92543420eed129c14e364769b0f32c27bdf4c61299fce8f8156af7477cac6a43931a20  vmlinuz-x86_64"
+          initramfs: "be7c3d57e2d73bfa4e41a2b5740c722b1c83722e4388b3cff9017192fce43ede360221e3095c800e511d7b4bce6065f2906883421409dd6d983412418a8d903e  initramfs-x86_64"
       - url: https://github.com/tinkerbell/hook/releases/download/v0.7.0/hook_aarch64.tar.gz
         sha512sum:
           kernel: "2f1bdbf64380e281288f54c6ddd29221d8a007d29b40f405da0592ed32ef6e52695fc5071e05b2db3f075122943d62a2c266704d154a16ffb7b278c70538e7da  vmlinuz-aarch64"

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -33,12 +33,13 @@ stack:
     # Customize the interface KubeVIP advertises on. When unset, KubeVIP will autodetect the
     # interface.
     #interface: enp0s8
-  relay:
+  relay: # relay allows us to listen and respond to layer broadcast DHCP requests
     name: dhcp-relay
     enabled: true
+    # This image (ghcr.io/jacobweinstock/dhcrelay) is used because `dhcrelay` doesn't respect signals properly when run as PID 1.
     image: ghcr.io/jacobweinstock/dhcrelay
     maxHopCount: 10
-    # sourceInterface is the host/node interface to listen on for DHCP broadcast packets.
+    # sourceInterface is the Host/Node interface to use for listening for DHCP broadcast packets.
     sourceInterface: eno1 # TODO(jacobweinstock): investigate autodetecting a default
 
 # -- Overrides
@@ -51,7 +52,7 @@ boots:
   image: quay.io/tinkerbell/boots:v0.8.0
   tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.8.0
   trustedProxies: []
-  # This will be the IP address that machines use to reach Boots for netbooting. It should be a unused IP address in your network.
+  # This will be the IP address that machines use to reach Boots (via unicast for DHCP) for netbooting. It should be a unused IP address in your network.
   remoteIp: 192.168.2.113
   # Once the Kubernetes Gateway API is more stable, we will use that and be able to require only a single IP for all Tinkerbell services.
   tinkServer:

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -13,7 +13,7 @@ stack:
     enabled: true
     name: hook-files
     port: 8080
-    image: alpine
+    image: ubuntu
     downloads:
       - url: https://github.com/tinkerbell/hook/releases/download/v0.7.0/hook_x86_64.tar.gz
         sha512sum:
@@ -33,6 +33,13 @@ stack:
     # Customize the interface KubeVIP advertises on. When unset, KubeVIP will autodetect the
     # interface.
     #interface: eth0
+  relay:
+    enabled: true
+    image: ghcr.io/jacobweinstock/dhcrelay
+    maxHopCount: 10
+    # sourceInterface is the host/node interface to listen on for DHCP broadcast packets.
+    sourceInterface: eno1
+    sourceIP: 192.168.2.63/24
 
 # -- Overrides
 # The values defined here override those in the individual charts. Some of them require tweaking
@@ -46,8 +53,6 @@ boots:
   trustedProxies: []
   # In most cases this value will be the same as `stack.loadBalancerIP`.
   remoteIp: 192.168.2.111
-  # hostNetwork: true is already the default in the Boots chart, but is included here for clarity.
-  hostNetwork: true
 
 hegel:
   image: quay.io/tinkerbell/hegel:v0.10.1

--- a/tinkerbell/tink/Chart.yaml
+++ b/tinkerbell/tink/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/tink/templates/tink-server/service.yaml
+++ b/tinkerbell/tink/templates/tink-server/service.yaml
@@ -7,7 +7,6 @@ metadata:
   name: {{ .Values.server.name }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  clusterIP: None
   ports:
   - port: {{ .Values.server.service.port }}
     protocol: TCP


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This enables Boots to be deployed, scaled, etc in normal Kubernetes ways instead of the current limiting paradigm of using host networking. Also, host networking is only needed for DHCP broadcast requests and Boots serves many other things. TFTP, HTTP, Syslog.

While this requires an additional load balancer IP for Boots, it's the most reliable way to get unicast traffic into Boots. Once we migrate to the [Kubernetes gateway API ](https://gateway-api.sigs.k8s.io/) we can go back to a single IP for all services.

Other updates include:

- use cluster ips in all charts
- default to hostNetwork: false in Boots chart
- use RollingUpdate deployment strategy in Boots chart
- use trailing dot in all FQDN references (fixes issues found in KinD deployments)
- Move to ubuntu image for downloading Hook (fixes issues found in KinD deployments)


## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
