### PR TITLE
Update CRDs so rufio can handle virtual media

### DIFF
--- a/tinkerbell/rufio/Chart.yaml
+++ b/tinkerbell/rufio/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.2"
+appVersion: "0.3.0"

--- a/tinkerbell/rufio/crds/bmc.tinkerbell.org_jobs.yaml
+++ b/tinkerbell/rufio/crds/bmc.tinkerbell.org_jobs.yaml
@@ -118,6 +118,20 @@ spec:
                       - cycle
                       - reset
                       type: string
+                    virtualMediaAction:
+                      description: VirtualMediaAction represents a baseboard management
+                        virtual media insert/eject.
+                      properties:
+                        kind:
+                          type: string
+                        mediaURL:
+                          description: mediaURL represents the URL of the image to
+                            be inserted into the virtual media, or empty to eject
+                            media.
+                          type: string
+                      required:
+                      - kind
+                      type: object
                   type: object
                 minItems: 1
                 type: array

--- a/tinkerbell/rufio/crds/bmc.tinkerbell.org_tasks.yaml
+++ b/tinkerbell/rufio/crds/bmc.tinkerbell.org_tasks.yaml
@@ -106,6 +106,19 @@ spec:
                     - cycle
                     - reset
                     type: string
+                  virtualMediaAction:
+                    description: VirtualMediaAction represents a baseboard management
+                      virtual media insert/eject.
+                    properties:
+                      kind:
+                        type: string
+                      mediaURL:
+                        description: mediaURL represents the URL of the image to be
+                          inserted into the virtual media, or empty to eject media.
+                        type: string
+                    required:
+                    - kind
+                    type: object
                 type: object
             required:
             - task

--- a/tinkerbell/rufio/values.yaml
+++ b/tinkerbell/rufio/values.yaml
@@ -1,6 +1,6 @@
 deploy: true
 name: rufio
-image: quay.io/tinkerbell/rufio:v0.2.2
+image: quay.io/tinkerbell/rufio:v0.3.0
 imagePullPolicy: IfNotPresent
 resources:
   requests:

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.2.1
 - name: rufio
   repository: file://../rufio
-  version: 0.2.3
+  version: 0.2.4
 - name: hegel
   repository: file://../hegel
   version: 0.3.1
-digest: sha256:2f9da61090928e4b22b1e95bda787b67955ccd711f95cc71bc9f256fc6446531
-generated: "2023-02-24T14:30:19.632765086-07:00"
+digest: sha256:aa1b615315c4c819893c0657517a24d430068277bca3f3d0ce06f8c198199195
+generated: "2023-03-10T16:12:14.071602-06:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: "0.2.1"
     repository: "file://../boots"
   - name: rufio
-    version: "0.2.3"
+    version: "0.2.4"
     repository: "file://../rufio"
   - name: hegel
     version: "0.3.1"


### PR DESCRIPTION
## Description

Virtual media support was added to rufio in https://github.com/tinkerbell/rufio/pull/79. This PR exposes the functionality here.

It should probably also bump the rufio version, but I think a maintainer might have to publish a new release first?

## Why is this needed

## How Has This Been Tested?

Booted a cluster with virtual media after installing tinkerbell with these charts.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
