### PR TITLE
Add cluster dns as template value

### DIFF
--- a/tinkerbell/stack/templates/nginx-configmap.yaml
+++ b/tinkerbell/stack/templates/nginx-configmap.yaml
@@ -20,7 +20,7 @@ data:
         location / {
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          resolver $POD_NAMESERVER;
+          resolver {{ .Values.stack.clusterDNS }};
           set $hegel_dns {{ .Values.hegel.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
 
           proxy_pass http://$hegel_dns:{{ .Values.hegel.deployment.port }};
@@ -32,9 +32,8 @@ data:
         location / {
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          resolver $POD_NAMESERVER;
+          resolver {{ .Values.stack.clusterDNS }};
           set $tink_dns {{ .Values.tink.server.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
-
           grpc_pass grpc://$tink_dns:{{ .Values.tink.server.deployment.port }};
         }
       }

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -29,9 +29,7 @@ spec:
         image: {{ .Values.stack.image }}
         command: ["/bin/bash", "-c"]
         args:
-        - export POD_NAMESERVER=$(awk 'NR==2 {print $2}' /etc/resolv.conf);
-          envsubst '$POD_NAMESERVER' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf;
-          nginx -g 'daemon off;'
+        - nginx -g 'daemon off;'
         ports:
         - containerPort: {{ .Values.hegel.deployment.port }}
           protocol: TCP

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -9,6 +9,8 @@ stack:
   loadBalancerIP: 192.168.2.112
   lbClass: kube-vip.io/kube-vip-class
   image: nginx:1.23.1
+  # clusterDNS represents the ip address of the cluster dns server ip. NodeLocalDNSCache ip for example is 169.254.20.10.
+  clusterDNS: 169.254.20.10
   hook:
     enabled: true
     name: hook-files


### PR DESCRIPTION
## Description
This PR introduces a new field in the `values.yaml` file, to specify the kubernetes cluster dns ip, which can be used during the chart installation, instead of extracting the cluster dns from the `/etc/resolve.conf` file.
<!--- Please describe what this PR is going to change -->

## Why is this needed
Currently, we read the dns server ip from the `/etc/resolve.conf` file and then propagate it to the tink stack nginx server configuration. This however, would limit reading this configuration from within the machine only, thus it is not easily managed and there can be almost no overriding logic. Another problem can be, the way that we currently read the dns namesever, we expect the `resolve.conf` file to be formatted in a certain way so we can extract the nameserver ip:
```shell
export POD_NAMESERVER=$(awk 'NR==2 {print $2}' /etc/resolv.conf);
envsubst '$POD_NAMESERVER' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf;
nginx -g 'daemon off;'
```

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Created a new k8s cluster
- Installed NodeLocalDNS in that k8s cluster 
- Specified the ip address of the default cluster dns ip for node local dns
- Made sure that, nginx config file has picked up that ip

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
