### PR TITLE
Disable mounting /opt/hook from host if stack.hook.enabled is set to false

### DIFF
--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -50,8 +50,10 @@ spec:
             cpu: 10m
             memory: 64Mi
         volumeMounts:
+        {{- if .Values.stack.hook.enabled }}
         - mountPath: /usr/share/nginx/html
           name: hook-artifacts
+        {{- end }}
         - mountPath: /tmp
           readOnly: true
           name: nginx-conf
@@ -81,10 +83,12 @@ spec:
           name: hook-artifacts
       {{- end }}
       volumes:
+      {{- if .Values.stack.hook.enabled }}
       - name: hook-artifacts
         hostPath:
           path: /opt/hook
           type: DirectoryOrCreate
+      {{- end }}
       - name: nginx-conf
         configMap:
           name: nginx-conf


### PR DESCRIPTION
This ensures that whatever pre-built Kernel image had been baked into the NGINX Docker image is served.

## Description

Due to missing device drivers in the vanilla Hook Linux Kernel we had to build our own. To avoid having to host an additional HTTP(S) server that serves the resulting Kernel image and Ramdisk we had decided to directly bake those files into the NGINX Docker Image and overriden the `stack.image` value accordingly.

By setting `stack.hook.enabled` we can disable the init container that pulls files from a 3rd party HTTP(S) server. However this doesn't work, as an empty `/opt/hook` directory from the host is still mounted into the target Pod.

This MR changes this behavior. When `stack.hook.enabled` is set to `false` only the Kernel files already in the Hook Docker Image are served instead.

## Why is this needed

No corresponding issue has been created.

## How Has This Been Tested?

- Create custom Hook Docker image with our own Kernel image and Ramdisk.
- Install Tinkerbell via the `stack` Helm chart with the code change of this MR applied.
- Enjoy booting into a customized Hook Linux with customized Kernel.

## How are existing users impacted? What migration steps/scripts do we need?

- Users wo have `stack.hook.enabled` set to `false` and expect files from the `/opt/hook` host directory will be impacted due to changed semantics.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
