### PR TITLE
only set the loadBalancerClass property when the user sets it to a non-empty value

### DIFF
--- a/tinkerbell/boots/templates/service.yaml
+++ b/tinkerbell/boots/templates/service.yaml
@@ -10,7 +10,9 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   {{- if eq .Values.service.type "LoadBalancer" }}
+  {{- if .Values.service.class }}
   loadBalancerClass: {{ .Values.service.class }}
+  {{- end }}
   loadBalancerIP: {{ $loadBalancerIP }}
   {{- end }}
   externalTrafficPolicy: Local

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -107,7 +107,9 @@ metadata:
 spec:
   type: {{ .Values.stack.service.type }}
   {{- if eq .Values.stack.service.type "LoadBalancer" }}
+  {{- if .Values.stack.lbClass }}
   loadBalancerClass: {{ .Values.stack.lbClass }}
+  {{- end }}
   loadBalancerIP: {{ .Values.stack.loadBalancerIP }}
   {{- end }}
   externalTrafficPolicy: Local


### PR DESCRIPTION
## Description

only set the loadBalancerClass property when the user sets it to a non-empty value.

this allows us to easily use the cluster default load balancer class.

## Why is this needed


this is required to use metallb instead of kube-vip.

here's an usage example:

```bash
helm upgrade --install \
  stack \
  . \
  --create-namespace \
  --namespace tink-system \
  --wait \
  --values <(cat <<EOF
stack:
  ...
  lbClass: ""
  kubevip:
    enabled: false
boots:
  service:
    class: ""
  ...
EOF
)
```

## How Has This Been Tested?

It was tested in a k3s cluster using metallb.

## How are existing users impacted? What migration steps/scripts do we need?

It does not impact existing users as there are no breaking changes.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
