### PR TITLE
Simplify the nginx commands and verify the checksums after download

### DIFF
--- a/tinkerbell/stack/README.md
+++ b/tinkerbell/stack/README.md
@@ -76,8 +76,7 @@ helm uninstall stack-release --namespace tink-system
 | `stack.hook.image` | Image to use for downloading the Hook artifacts | `alpine` |
 | `stack.hook.downloads` | List of Hook artifacts to download | `[]` |
 | `stack.hook.downloads[0].url` | URL of the Hook bundle to download | `""` |
-| `stack.hook.downloads[0].sha512sum.kernel` | sha512sum, 2 spaces, and name of the Hook kernel in the bundle | `"7c..20  vmlinuz-x86_64"` |
-| `stack.hook.downloads[0].sha512sum.initramfs` | sha512sum, 2 spaces, and name of the Hook initramfs in the bundle | `""` |
+| `stack.hook.downloads[0].sha512sum` | sha512sum of the Hook bundle | `""` |
 
 ### Load Balancer Parameters (kube-vip)
 

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -27,11 +27,14 @@ spec:
       containers:
       - name: {{ .Values.stack.name }}
         image: {{ .Values.stack.image }}
-        command: ["/bin/bash", "-c"]
+        command: ["/bin/bash", "-xeuc"]
         args:
-        - export POD_NAMESERVER=$(awk 'NR==2 {print $2}' /etc/resolv.conf);
-          envsubst '$POD_NAMESERVER' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf;
-          nginx -g 'daemon off;'
+        - |
+          POD_NAMESERVER=$(awk 'NR==2 {print $2}' /etc/resolv.conf) \
+            envsubst '$POD_NAMESERVER' \
+            </tmp/nginx.conf.template \
+            >/etc/nginx/nginx.conf
+          exec nginx -g 'daemon off;'
         ports:
         - containerPort: {{ .Values.hegel.deployment.port }}
           protocol: TCP

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -64,23 +64,24 @@ spec:
       initContainers:
       - name: init-hook-download
         image: {{ .Values.stack.hook.image }}
-        command: ["/bin/sh", "-xec"]
-        args: # TODO(jacobweinstock): add checksum verification after download
-        - rm -rf /usr/share/nginx/html/checksums.txt;
-          touch /usr/share/nginx/html/checksums.txt;
+        command: ["/bin/bash", "-xeuc"]
+        args:
+        - |
+          apt-get update
+          apt-get install -y wget
+          cd /usr/share/nginx/html
           {{- range $index, $keys := .Values.stack.hook.downloads }}
-          echo "{{ $keys.sha512sum.kernel }}" >> /usr/share/nginx/html/checksums.txt;
-          echo "{{ $keys.sha512sum.initramfs }}" >> /usr/share/nginx/html/checksums.txt;
+          wget -O /tmp/hook{{ $index }}.tar.gz {{ $keys.url }}
+          tar -zxvf /tmp/hook{{ $index }}.tar.gz
+          rm /tmp/hook{{ $index }}.tar.gz
           {{- end }}
-          cd /usr/share/nginx/html/;
-          sha512sum -c checksums.txt && exit 0;
+          cat >checksums.txt <<'EOF'
           {{- range $index, $keys := .Values.stack.hook.downloads }}
-          echo downloading HOOK...;
-          apt-get update && apt-get install -y wget;
-          wget -O /tmp/hook{{ $index }}.tar.gz {{ $keys.url }};
-          tar -zxvf /tmp/hook{{ $index }}.tar.gz -C "/usr/share/nginx/html/";
-          rm -rf /tmp/hook{{ $index }}.tar.gz;
+          {{ $keys.sha512sum.kernel }}
+          {{ $keys.sha512sum.initramfs }}
           {{- end }}
+          EOF
+          sha512sum --check checksums.txt
         volumeMounts:
         - mountPath: /usr/share/nginx/html
           name: hook-artifacts

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -71,17 +71,15 @@ spec:
           apt-get install -y wget
           cd /usr/share/nginx/html
           {{- range $index, $keys := .Values.stack.hook.downloads }}
-          wget -O /tmp/hook{{ $index }}.tar.gz {{ $keys.url }}
-          tar -zxvf /tmp/hook{{ $index }}.tar.gz
-          rm /tmp/hook{{ $index }}.tar.gz
-          {{- end }}
-          cat >checksums.txt <<'EOF'
-          {{- range $index, $keys := .Values.stack.hook.downloads }}
-          {{ $keys.sha512sum.kernel }}
-          {{ $keys.sha512sum.initramfs }}
-          {{- end }}
+          p=/tmp/hook{{ $index }}.tar.gz
+          rm -f $p
+          wget -O $p {{ $keys.url }}
+          sha512sum --check <<EOF
+          {{ $keys.sha512sum }} $p
           EOF
-          sha512sum --check checksums.txt
+          tar -zxvf $p
+          rm -f $p
+          {{- end }}
         volumeMounts:
         - mountPath: /usr/share/nginx/html
           name: hook-artifacts

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -16,13 +16,9 @@ stack:
     image: ubuntu
     downloads:
       - url: https://github.com/tinkerbell/hook/releases/download/v0.8.0/hook_x86_64.tar.gz
-        sha512sum:
-          kernel: "45a83dc747ff05fda09dc7a3b376fca3d82079fbfe99927d9f1c935f2070b5ac6469a41387fefd9e2eeb51062959846900583274a5d02e4131f37162a6167b28  vmlinuz-x86_64"
-          initramfs: "17ca45318762975464e7abd8f09316d96a658cbbf38c46a47b1ff6f712cffc23d035091883e7e94c21a3b54d8f67c4a982e1fac206449d79f86773ea8c6b7ec6  initramfs-x86_64"
+        sha512sum: 498cccba921c019d4526a2a562bd2d9c8efba709ab760fa9d38bd8de1efeefc8e499c9249af9571aa28a1e371e6c928d5175fa70d5d7addcf3dd388caeff1a45
       - url: https://github.com/tinkerbell/hook/releases/download/v0.8.0/hook_aarch64.tar.gz
-        sha512sum:
-          kernel: "80c14e9b2407aabe59b40d7d60e0b96cb2b8812a13d9c278ad1f042aea510d6ff0e4de3c42e39ed049fda871564744cd9f2559d72c3f010331dde62c18af2c77  vmlinuz-aarch64"
-          initramfs: "5a4eaea8c77c0e574ae3264ddec25a35e758205a75931a61a7911d2b5ac7151e2711a3633b08c05ffc89ab26f81224ea60bb420dab65fd1ccd0b77990db0361a  initramfs-aarch64"
+        sha512sum: 56e3959722c9ae85aec6c214448108e2dc1d581d2c884ca7a23265c1ae28489589481730fbb941fac8239f6222f9b5bb757987a5238f20194e184ae7e83b6a5b
   kubevip:
     enabled: true
     name: kube-vip


### PR DESCRIPTION
## Description

Simplify the nginx commands and verify the checksums after download.

## Why is this needed

Simplifies the code.

## How Has This Been Tested?

Tested by launching the k8s stack in https://github.com/rgl/tinkerbell-k8s-vagrant

## How are existing users impacted? What migration steps/scripts do we need?

None.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
