### PR TITLE
Removed unused and possibly duplicate label selector

### DIFF
--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -124,7 +124,6 @@ spec:
     port: {{ .Values.stack.hook.port }}
     protocol: TCP
   selector:
-    app: stack
     {{- with .Values.stack.selector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## Description

When creating the helm chart, analysing the output, I noticed a duplicate label selector (`app: stack`). I searched for usage of this selector but found none. I propose to delete this selector for this reason.

## Why is this needed

Because I the current label is confusing and irrelevant.

Fixes: Duplicate label

## How Has This Been Tested?
I have installed the helm chart on an empty cluster.
I have gained the helm chart manifest files using the `--dry-run` flag.
I have removed the key and value from in the tink-stack load balancer service.
I have applied the changes using kustomize combining al the manifest files gained form the helm dry-run.
I have verified that the application is still working.

## How are existing users impacted? What migration steps/scripts do we need?
None
