### PR TITLE
bump tinkerbell/boots to version v0.9.0

### DIFF
--- a/tinkerbell/boots/Chart.yaml
+++ b/tinkerbell/boots/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.2.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.0"
+appVersion: "0.9.0"

--- a/tinkerbell/boots/templates/deployment.yaml
+++ b/tinkerbell/boots/templates/deployment.yaml
@@ -55,6 +55,10 @@ spec:
               value: {{ printf "%s:%v" $tinkServerIp .Values.tinkServer.port | quote }}
             - name: TINKERBELL_TLS
               value: {{ .Values.tinkServer.tls | quote }}
+            - name: BOOTS_EXTRA_KERNEL_ARGS
+              value: {{ join " " ( append .Values.additionlKernelArgs ( printf "tink_worker_image=%s" ( required "missing tinkWorkerImage" .Values.tinkWorkerImage ) ) ) | quote }}
+            - name: BOOTS_LOG_LEVEL
+              value: {{ .Values.logLevel | quote }}
             {{- range .Values.additionalEnv }}
             - name: {{ .name | quote }}
               value: {{ .value | quote }}

--- a/tinkerbell/boots/templates/deployment.yaml
+++ b/tinkerbell/boots/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
             - -ipxe-tftp-addr={{ printf "%v:%v" .Values.tftp.ip .Values.tftp.port }}
             - -http-addr={{ printf "%v:%v" .Values.http.ip .Values.http.port }}
             - -syslog-addr={{ printf "%v:%v" .Values.syslog.ip .Values.syslog.port }}
+            - -osie-url={{ printf "%v://%v:%v" .Values.osieBase.protocol $osieBaseIp .Values.osieBase.port }}
           {{- range .Values.additionalArgs }}
             - {{ . }}
           {{- end }}

--- a/tinkerbell/boots/templates/deployment.yaml
+++ b/tinkerbell/boots/templates/deployment.yaml
@@ -38,7 +38,6 @@ spec:
             - -ipxe-tftp-addr={{ printf "%v:%v" .Values.tftp.ip .Values.tftp.port }}
             - -http-addr={{ printf "%v:%v" .Values.http.ip .Values.http.port }}
             - -syslog-addr={{ printf "%v:%v" .Values.syslog.ip .Values.syslog.port }}
-            - -osie-path-override={{ printf "%v://%v:%v" .Values.osieBase.protocol $osieBaseIp .Values.osieBase.port }}
           {{- range .Values.additionalArgs }}
             - {{ . }}
           {{- end }}
@@ -47,10 +46,6 @@ spec:
               value: {{ required "missing trustedProxies" ( join "," .Values.trustedProxies | quote ) }}
             - name: DATA_MODEL_VERSION
               value: "kubernetes"
-            - name: FACILITY_CODE
-              value: "lab1"
-            - name: MIRROR_BASE_URL
-              value: {{ printf "%v://%v:%v" .Values.osieBase.protocol $osieBaseIp .Values.osieBase.port | quote }}
             - name: PUBLIC_IP
               value: {{ $remoteDhcpIp | quote }}
             - name: PUBLIC_SYSLOG_FQDN
@@ -59,10 +54,6 @@ spec:
               value: {{ printf "%s:%v" $tinkServerIp .Values.tinkServer.port | quote }}
             - name: TINKERBELL_TLS
               value: {{ .Values.tinkServer.tls | quote }}
-            - name: BOOTS_EXTRA_KERNEL_ARGS
-              value: {{ join " " ( append .Values.additionlKernelArgs ( printf "tink_worker_image=%s" ( required "missing tinkWorkerImage" .Values.tinkWorkerImage ) ) ) | quote }}
-            - name: BOOTS_LOG_LEVEL
-              value: {{ .Values.logLevel | quote }}
             {{- range .Values.additionalEnv }}
             - name: {{ .name | quote }}
               value: {{ .value | quote }}

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -5,7 +5,7 @@ deploy: true
 name: boots
 
 # The image used to launch the container.
-image: quay.io/tinkerbell/boots:v0.8.0
+image: quay.io/tinkerbell/boots:v0.9.0
 imagePullPolicy: IfNotPresent
 
 # The number of pods to run.
@@ -32,9 +32,6 @@ service:
   type: LoadBalancer
   class: kube-vip.io/kube-vip-class
   loadBalancerIP: ""
-
-# The log level for the container.
-logLevel: "info"
 
 # The network mode to launch the boots container. When true, the boots container will use the
 # host network.

--- a/tinkerbell/boots/values.yaml
+++ b/tinkerbell/boots/values.yaml
@@ -33,6 +33,9 @@ service:
   class: kube-vip.io/kube-vip-class
   loadBalancerIP: ""
 
+# The log level for the container.
+logLevel: "info"
+
 # The network mode to launch the boots container. When true, the boots container will use the
 # host network.
 hostNetwork: false


### PR DESCRIPTION
## Description
A new tag for Boots has been released(v0.9.0) and few argument and env variables have been removed. Those are: 

Args: `-osie-path-override`
Env: `FACILITY_CODE`, `MIRROR_BASE_URL`, `BOOTS_EXTRA_KERNEL_ARGS` and `BOOTS_LOG_LEVEL`

This PR cleans up those args and env vars. 
<!--- Please describe what this PR is going to change -->

## Why is this needed
Clean up missing/deleted args and env vars after bumping boots version. 
<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?
<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
