### PR TITLE
allow annotations on stack nginx service

### DIFF
--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -139,6 +139,10 @@ metadata:
     app: {{ .Values.stack.name }}
   name: {{ .Values.stack.name }}
   namespace: {{ .Release.Namespace | quote }}
+  annotations:
+  {{- with .Values.stack.service.annotations | default dict }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.stack.service.type }}
   {{- if eq .Values.stack.service.type "LoadBalancer" }}


### PR DESCRIPTION
This allows choosing an IP, for example. Or getting an SSL cert

## Description

This alows adding annotations to the nginx service, like:

```
service:
  annotations:
    metallb.universe.tf/address-pool: bgp
```

## Why is this needed

It is sometimes needed to add annotations depending on the configuration of the cluster, like if you want to use kubevip instead of the normal ingress.

Fixes: #

## How Has This Been Tested?
I've tried it both with and without annotations, and it works both way, but with annotations for my metallb address-pool, the service gets a BGP address, and not an ARP'd address.


## How are existing users impacted? What migration steps/scripts do we need?
This should be transparent, default dict is empty, so no annotations are the default.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
