### PR TITLE
Allow persistentStorage - opens up multinode

### DIFF
--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -84,10 +84,17 @@ spec:
       {{- end }}
       volumes:
       {{- if .Values.stack.hook.enabled }}
+      {{- if not .Values.stack.hook.persistentStorage }}
       - name: hook-artifacts
         hostPath:
           path: {{ .Values.stack.hook.downloadsDest }}
           type: DirectoryOrCreate
+      {{- end }}
+      {{- if .Values.stack.hook.persistentStorage }}
+      - name: hook-artifacts
+        persistentVolumeClaim:
+          claimName: hook-artifacts
+      {{- end }}
       {{- end }}
       - name: nginx-conf
         configMap:
@@ -95,6 +102,22 @@ spec:
           items:
             - key: nginx.conf
               path: nginx.conf.template
+{{- if .Values.stack.hook.persistentStorage }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hook-artifacts
+spec:
+  {{- if .Values.stack.hook.storageClass }}
+  storageClassName: {{ .Values.stack.hook.storageClass }}
+  {{- end }}
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+{{- end }}
 {{- if .Values.stack.service.enabled }}
 ---
 apiVersion: v1

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -18,6 +18,8 @@ stack:
     port: 8080
     image: alpine
     downloadsDest: /opt/hook
+    persistentStorage: true
+    storageClass: ceph-filesystem
     downloads:
       - url: https://github.com/tinkerbell/hook/releases/download/v0.8.1/hook_x86_64.tar.gz
         sha512sum: 29d8cf6991272eea20499d757252b07deba824eb778368192f9ab88b215a0dafa584e83422dac08feeb43ddce65f485557ad66210f005a81ab95fb53b7d8d424


### PR DESCRIPTION
## Description

An example of what I did to fix #42, it works great for me!

It's also needed to be added to image downloading (https://github.com/tinkerbell/sandbox/blob/4195ea1c46f7ea9e70f297be190a81ed00ba2ec9/deploy/stack/helm/manifests/ubuntu-download.yaml) like I did here: https://github.com/ClashTheBunny/tink-settings/blob/main/tink-system/templates/download.yaml

## Why is this needed

Multiple nodes

Fixes: #

## How Has This Been Tested?
Works for me!

## How are existing users impacted? What migration steps/scripts do we need?

The default should be not to have any change, but I'm including the overridden value to show where it would need to change.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
