### PR TITLE
Add stack persistent volume claim

### DIFF
--- a/tinkerbell/stack/templates/NOTES.txt
+++ b/tinkerbell/stack/templates/NOTES.txt
@@ -1,0 +1,7 @@
+{{- if eq (include "stack.hookDownloadJobEnabled" .) "false" }}
+Warning:
+
+You are using no persistence or ReadWriteOnce access modes on PersistentVolumeClaim, Job `download-hook` is disabled.
+You will need to manage hooks artifacts manually.
+Also stack Deployment is not scalable.
+{{- end }}

--- a/tinkerbell/stack/templates/NOTES.txt
+++ b/tinkerbell/stack/templates/NOTES.txt
@@ -1,7 +1,0 @@
-{{- if eq (include "stack.hookDownloadJobEnabled" .) "false" }}
-Warning:
-
-You are using no persistence or ReadWriteOnce access modes on PersistentVolumeClaim, Job `download-hook` is disabled.
-You will need to manage hooks artifacts manually.
-Also stack Deployment is not scalable.
-{{- end }}

--- a/tinkerbell/stack/templates/_helpers.tpl
+++ b/tinkerbell/stack/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "stack.hookDownloadJobEnabled" -}}
+{{- $result := .Values.stack.persistence.enabled }}
+{{- if and .Values.stack.persistence.enabled (eq .Values.stack.persistence.type "pvc") }}
+  {{- range .Values.stack.persistence.accessModes }}
+    {{- if eq . "ReadWriteOnce" }}
+      {{- $result = false}}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $result }}
+{{- end -}}

--- a/tinkerbell/stack/templates/_helpers.tpl
+++ b/tinkerbell/stack/templates/_helpers.tpl
@@ -1,11 +1,14 @@
 {{- define "stack.hookDownloadJobEnabled" -}}
-{{- $result := .Values.stack.persistence.enabled }}
-{{- if and .Values.stack.persistence.enabled (eq .Values.stack.persistence.type "pvc") }}
-  {{- range .Values.stack.persistence.accessModes }}
-    {{- if eq . "ReadWriteOnce" }}
-      {{- $result = false}}
+  {{- $result := false }}
+  {{- if and .Values.stack.hook.enabled .Values.stack.hook.persistence.enabled -}}
+    {{- $result = true -}}
+    {{- if and .Values.stack.hook.persistence.enabled (eq .Values.stack.hook.persistence.type "pvc") }}
+      {{- range .Values.stack.hook.persistence.accessModes }}
+        {{- if eq . "ReadWriteOnce" }}
+          {{- $result = false}}
+        {{- end }}
+      {{- end }}
     {{- end }}
-  {{- end }}
-{{- end }}
-{{- $result }}
+  {{- end -}}
+  {{- $result }}
 {{- end -}}

--- a/tinkerbell/stack/templates/_hook.tpl
+++ b/tinkerbell/stack/templates/_hook.tpl
@@ -3,7 +3,7 @@
   {{- if and .Values.stack.hook.enabled .Values.stack.hook.persistence.enabled -}}
     {{- $result = true -}}
     {{- if and .Values.stack.hook.persistence.enabled (eq .Values.stack.hook.persistence.type "pvc") }}
-      {{- range .Values.stack.hook.persistence.accessModes }}
+      {{- range .Values.stack.hook.persistence.pvc.accessModes }}
         {{- if eq . "ReadWriteOnce" }}
           {{- $result = false}}
         {{- end }}

--- a/tinkerbell/stack/templates/hook.yaml
+++ b/tinkerbell/stack/templates/hook.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.stack.hook.enabled }}
+{{- $hookDownloadJobEnabled := eq (include "stack.hookDownloadJobEnabled" .) "true" -}}
+{{- if and .Values.stack.hook.enabled $hookDownloadJobEnabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -48,9 +49,20 @@ spec:
       restartPolicy: OnFailure
       volumes:
         - name: hook-artifacts
+          {{- if .Values.stack.persistence.enabled }}
+          {{- if eq .Values.stack.persistence.type "hostpath" }}
           hostPath:
             path: {{ .Values.stack.hook.downloadsDest }}
             type: DirectoryOrCreate
+          {{- else if eq .Values.stack.persistence.type "pvc" }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.stack.persistence.existingClaim | default "hook-artifacts" }}
+          {{- else }}
+          {{- fail "value for .Values.stack.persistence.type is not as expected" }}
+          {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: configmap-volume
           configMap:
             defaultMode: 0700

--- a/tinkerbell/stack/templates/hook.yaml
+++ b/tinkerbell/stack/templates/hook.yaml
@@ -49,16 +49,16 @@ spec:
       restartPolicy: OnFailure
       volumes:
         - name: hook-artifacts
-          {{- if .Values.stack.persistence.enabled }}
-          {{- if eq .Values.stack.persistence.type "hostpath" }}
+          {{- if .Values.stack.hook.persistence.enabled }}
+          {{- if eq .Values.stack.hook.persistence.type "hostpath" }}
           hostPath:
             path: {{ .Values.stack.hook.downloadsDest }}
             type: DirectoryOrCreate
-          {{- else if eq .Values.stack.persistence.type "pvc" }}
+          {{- else if eq .Values.stack.hook.persistence.type "pvc" }}
           persistentVolumeClaim:
-            claimName: {{ .Values.stack.persistence.existingClaim | default "hook-artifacts" }}
+            claimName: {{ .Values.stack.hook.persistence.existingClaim | default "hook-artifacts" }}
           {{- else }}
-          {{- fail "value for .Values.stack.persistence.type is not as expected" }}
+          {{- fail "value for .Values.stack.hook.persistence.type is not as expected" }}
           {{- end }}
           {{- else }}
           emptyDir: {}

--- a/tinkerbell/stack/templates/hook.yaml
+++ b/tinkerbell/stack/templates/hook.yaml
@@ -50,16 +50,16 @@ spec:
       volumes:
         - name: hook-artifacts
           {{- if .Values.stack.hook.persistence.enabled }}
-          {{- if eq .Values.stack.hook.persistence.type "hostpath" }}
+            {{- if eq .Values.stack.hook.persistence.type "hostpath" }}
           hostPath:
             path: {{ .Values.stack.hook.downloadsDest }}
             type: DirectoryOrCreate
-          {{- else if eq .Values.stack.hook.persistence.type "pvc" }}
+            {{- else if eq .Values.stack.hook.persistence.type "pvc" }}
           persistentVolumeClaim:
             claimName: {{ .Values.stack.hook.persistence.existingClaim | default "hook-artifacts" }}
-          {{- else }}
-          {{- fail "value for .Values.stack.hook.persistence.type is not as expected" }}
-          {{- end }}
+            {{- else }}
+              {{- fail "value for .Values.stack.hook.persistence.type is not as expected" }}
+            {{- end }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/tinkerbell/stack/templates/hook.yaml
+++ b/tinkerbell/stack/templates/hook.yaml
@@ -56,9 +56,9 @@ spec:
             type: DirectoryOrCreate
             {{- else if eq .Values.stack.hook.persistence.type "pvc" }}
           persistentVolumeClaim:
-            claimName: {{ .Values.stack.hook.persistence.existingClaim | default "hook-artifacts" }}
+            claimName: {{ .Values.stack.hook.persistence.pvc.existingClaim | default "hook-artifacts" }}
             {{- else }}
-              {{- fail "value for .Values.stack.hook.persistence.type is not as expected" }}
+              {{- fail "value for .Values.stack.hook.persistence.type is unsupported" }}
             {{- end }}
           {{- else }}
           emptyDir: {}

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -106,7 +106,7 @@ spec:
           type: DirectoryOrCreate
           {{- else if eq .Values.stack.hook.persistence.type "pvc" }}
         persistentVolumeClaim:
-          claimName: {{ .Values.stack.hook.persistence.existingClaim | default "hook-artifacts" }}
+          claimName: {{ .Values.stack.hook.persistence.pvc.existingClaim | default "hook-artifacts" }}
           {{- else }}
             {{- fail "value for .Values.stack.hook.persistence.type is not as expected" }}
           {{- end }}

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -99,16 +99,16 @@ spec:
               path: nginx.conf.template
       {{- if .Values.stack.hook.enabled }}
       - name: hook-artifacts
-        {{- if .Values.stack.persistence.enabled }}
-        {{- if eq .Values.stack.persistence.type "hostpath" }}
+        {{- if .Values.stack.hook.persistence.enabled }}
+        {{- if eq .Values.stack.hook.persistence.type "hostpath" }}
         hostPath:
           path: {{ .Values.stack.hook.downloadsDest }}
           type: DirectoryOrCreate
-        {{- else if eq .Values.stack.persistence.type "pvc" }}
+        {{- else if eq .Values.stack.hook.persistence.type "pvc" }}
         persistentVolumeClaim:
-          claimName: {{ .Values.stack.persistence.existingClaim | default "hook-artifacts" }}
+          claimName: {{ .Values.stack.hook.persistence.existingClaim | default "hook-artifacts" }}
         {{- else }}
-        {{- fail "value for .Values.stack.persistence.type is not as expected" }}
+        {{- fail "value for .Values.stack.hook.persistence.type is not as expected" }}
         {{- end }}
         {{- else }}
         emptyDir: {}

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -100,16 +100,16 @@ spec:
       {{- if .Values.stack.hook.enabled }}
       - name: hook-artifacts
         {{- if .Values.stack.hook.persistence.enabled }}
-        {{- if eq .Values.stack.hook.persistence.type "hostpath" }}
+          {{- if eq .Values.stack.hook.persistence.type "hostpath" }}
         hostPath:
           path: {{ .Values.stack.hook.downloadsDest }}
           type: DirectoryOrCreate
-        {{- else if eq .Values.stack.hook.persistence.type "pvc" }}
+          {{- else if eq .Values.stack.hook.persistence.type "pvc" }}
         persistentVolumeClaim:
           claimName: {{ .Values.stack.hook.persistence.existingClaim | default "hook-artifacts" }}
-        {{- else }}
-        {{- fail "value for .Values.stack.hook.persistence.type is not as expected" }}
-        {{- end }}
+          {{- else }}
+            {{- fail "value for .Values.stack.hook.persistence.type is not as expected" }}
+          {{- end }}
         {{- else }}
         emptyDir: {}
         {{- end }}

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -99,9 +99,20 @@ spec:
               path: nginx.conf.template
       {{- if .Values.stack.hook.enabled }}
       - name: hook-artifacts
+        {{- if .Values.stack.persistence.enabled }}
+        {{- if eq .Values.stack.persistence.type "hostpath" }}
         hostPath:
           path: {{ .Values.stack.hook.downloadsDest }}
           type: DirectoryOrCreate
+        {{- else if eq .Values.stack.persistence.type "pvc" }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.stack.persistence.existingClaim | default "hook-artifacts" }}
+        {{- else }}
+        {{- fail "value for .Values.stack.persistence.type is not as expected" }}
+        {{- end }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
       {{- end }}
       initContainers:
       - name: relay-macvlan-interface

--- a/tinkerbell/stack/templates/nginx_persistentvolumeclaim.yaml
+++ b/tinkerbell/stack/templates/nginx_persistentvolumeclaim.yaml
@@ -1,28 +1,28 @@
-{{- if and .Values.stack.persistence.enabled (not .Values.stack.persistence.existingClaim) (eq .Values.stack.persistence.type "pvc") }}
+{{- if and .Values.stack.hook.enabled .Values.stack.hook.persistence.enabled (not .Values.stack.hook.persistence.existingClaim) (eq .Values.stack.hook.persistence.type "pvc") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hook-artifacts
   labels:
-    {{- with .Values.stack.persistence.extraPvcLabels }}
+    {{- with .Values.stack.hook.persistence.extraPvcLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.stack.persistence.annotations  }}
+  {{- with .Values.stack.hook.persistence.annotations  }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   accessModes:
-    {{- range .Values.stack.persistence.accessModes }}
+    {{- range .Values.stack.hook.persistence.accessModes }}
     - {{ . | quote }}
     {{- end }}
   resources:
     requests:
-      storage: {{ .Values.stack.persistence.size | quote }}
-  {{- with .Values.stack.persistence.storageClassName }}
+      storage: {{ .Values.stack.hook.persistence.size | quote }}
+  {{- with .Values.stack.hook.persistence.storageClassName }}
   storageClassName: {{ . }}
   {{- end }}
-  {{- with .Values.stack.persistence.selectorLabels }}
+  {{- with .Values.stack.hook.persistence.selectorLabels }}
   selector:
     matchLabels:
     {{- toYaml . | nindent 6 }}

--- a/tinkerbell/stack/templates/nginx_persistentvolumeclaim.yaml
+++ b/tinkerbell/stack/templates/nginx_persistentvolumeclaim.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.stack.persistence.enabled (not .Values.stack.persistence.existingClaim) (eq .Values.stack.persistence.type "pvc") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hook-artifacts
+  labels:
+    {{- with .Values.stack.persistence.extraPvcLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.stack.persistence.annotations  }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.stack.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.stack.persistence.size | quote }}
+  {{- with .Values.stack.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.stack.persistence.selectorLabels }}
+  selector:
+    matchLabels:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/tinkerbell/stack/templates/nginx_persistentvolumeclaim.yaml
+++ b/tinkerbell/stack/templates/nginx_persistentvolumeclaim.yaml
@@ -1,30 +1,29 @@
-{{- if and .Values.stack.hook.enabled .Values.stack.hook.persistence.enabled (not .Values.stack.hook.persistence.existingClaim) (eq .Values.stack.hook.persistence.type "pvc") }}
+{{- if and .Values.stack.hook.enabled .Values.stack.hook.persistence.enabled (not .Values.stack.hook.persistence.pvc.existingClaim) (eq .Values.stack.hook.persistence.type "pvc") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hook-artifacts
   labels:
-    {{- with .Values.stack.hook.persistence.extraPvcLabels }}
+    {{- with .Values.stack.hook.persistence.pvc.extraLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.stack.hook.persistence.annotations  }}
+  {{- with .Values.stack.hook.persistence.pvc.annotations  }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   accessModes:
-    {{- range .Values.stack.hook.persistence.accessModes }}
+    {{- range .Values.stack.hook.persistence.pvc.accessModes }}
     - {{ . | quote }}
     {{- end }}
   resources:
     requests:
-      storage: {{ .Values.stack.hook.persistence.size | quote }}
-  {{- with .Values.stack.hook.persistence.storageClassName }}
+      storage: {{ .Values.stack.hook.persistence.pvc.size | quote }}
+  {{- with .Values.stack.hook.persistence.pvc.storageClassName }}
   storageClassName: {{ . }}
   {{- end }}
-  {{- with .Values.stack.hook.persistence.selectorLabels }}
-  selector:
-    matchLabels:
-    {{- toYaml . | nindent 6 }}
+  {{- with .Values.stack.hook.persistence.pvc.selector }}
+  selector: 
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -12,6 +12,20 @@ stack:
   lbClass: kube-vip.io/kube-vip-class
   # Once the Kubernetes Gateway API is more stable, we will use that for all services instead of nginx.
   image: nginx:1.25.1
+  persistence:
+    enabled: true
+    # type hostpath or pvc
+    type: hostpath
+    # When type is pvc
+    # storageClassName: default
+    accessModes:
+      - ReadWriteMany
+    size: 1Gi
+    # annotations: {}
+    # selectorLabels: {}
+    # existingClaim:
+    extraPvcLabels: {}
+
   hook:
     enabled: true
     name: hook-files

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -12,19 +12,7 @@ stack:
   lbClass: kube-vip.io/kube-vip-class
   # Once the Kubernetes Gateway API is more stable, we will use that for all services instead of nginx.
   image: nginx:1.25.1
-  persistence:
-    enabled: true
-    # type hostpath or pvc
-    type: hostpath
-    # When type is pvc
-    # storageClassName: default
-    accessModes:
-      - ReadWriteMany
-    size: 1Gi
-    # annotations: {}
-    # selectorLabels: {}
-    # existingClaim:
-    extraPvcLabels: {}
+  
 
   hook:
     enabled: true
@@ -35,6 +23,24 @@ stack:
     # downloadURL only works with the > 0.8.1 Hook release because
     # previous Hook versions didn't provide a checksum file.
     downloadURL: https://github.com/tinkerbell/hook/releases/download/latest
+    persistence:
+      enabled: true
+      ## type hostpath or pvc
+      # hostpath : only works on a single worker node cluster
+      type: hostpath
+      ## When type is pvc
+      # storageClassName: default
+
+      ## PVC accessModes : 
+      # Require ReadWriteMany in order to download Hook and scale up kubernetes tink-stack Deployment resource.
+      # If ReadWriteOnce is used, you will need to download manually Hook into stack Pod (/usr/share/nginx/html/).
+      accessModes:
+        - ReadWriteMany
+      size: 1Gi
+      # annotations: {}
+      # selectorLabels: {}
+      # existingClaim:
+      extraPvcLabels: {}
   kubevip:
     enabled: true
     name: kube-vip

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -30,9 +30,6 @@ stack:
       # https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
       type: hostpath
 
-      # The PVC storage class to use. Only valid with type=pvc.
-      # storageClassName: default
-
       pvc:
         # PVC accessModes : 
         # If you include only ReadWriteMany access mode it will allow to download Hook artifacts,
@@ -43,6 +40,7 @@ stack:
         accessModes:
           - ReadWriteMany
         size: 1Gi
+        # storageClassName: default
         # Annotations to include on the PVC object.
         annotations: {}
 

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -25,22 +25,36 @@ stack:
     downloadURL: https://github.com/tinkerbell/hook/releases/download/latest
     persistence:
       enabled: true
-      ## type hostpath or pvc
-      # hostpath : only works on a single worker node cluster
+      # type must be either "hostpath" or "pvc"
+      # hostpath: only works on a single worker node cluster
+      # https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
       type: hostpath
-      ## When type is pvc
+
+      # The PVC storage class to use. Only valid with type=pvc.
       # storageClassName: default
 
-      ## PVC accessModes : 
-      # Require ReadWriteMany in order to download Hook and scale up kubernetes tink-stack Deployment resource.
-      # If ReadWriteOnce is used, you will need to download manually Hook into stack Pod (/usr/share/nginx/html/).
-      accessModes:
-        - ReadWriteMany
-      size: 1Gi
-      # annotations: {}
-      # selectorLabels: {}
-      # existingClaim:
-      extraPvcLabels: {}
+      pvc:
+        # PVC accessModes : 
+        # If you include only ReadWriteMany access mode it will allow to download Hook artifacts,
+        # it will also allow to scale up stack deployment on multinode cluster.
+        # If ReadWriteOnce is included, you will need to download manually Hook artifacts into
+        # stack Pod (/usr/share/nginx/html/).
+        # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+        accessModes:
+          - ReadWriteMany
+        size: 1Gi
+        # Annotations to include on the PVC object.
+        annotations: {}
+
+        # An optional selector to narrow the Volumes considered for binding to the PVC.
+        # Should be structured the same as a raw PVC selector (see documentation for more info).
+        #
+        # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector.
+        selector: {}
+
+        # existingClaim:
+        extraLabels: {}
+
   kubevip:
     enabled: true
     name: kube-vip


### PR DESCRIPTION
## Description

A proposal to fix #42 like PR #63, taking into account the new method to download Hook artifacts with a Job (previously with an init container). PVC accessModes are checked to disable hook downloader Job and inform user when ReadWriteOnce is used (default to ReadWriteMany).

## Why is this needed

Fixes: #42 

## How Has This Been Tested?

Only tested with ReadWriteOnce PVC.
Checked generated manifests with helm install --debug --dry-run...

## How are existing users impacted? What migration steps/scripts do we need?

Actual default behavior should be preserved

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
