### PR TITLE
Update Rufio CRDs:

### DIFF
--- a/tinkerbell/rufio/Chart.yaml
+++ b/tinkerbell/rufio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/rufio/crds/bmc.tinkerbell.org_jobs.yaml
+++ b/tinkerbell/rufio/crds/bmc.tinkerbell.org_jobs.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: jobs.bmc.tinkerbell.org
 spec:
   group: bmc.tinkerbell.org
@@ -22,7 +21,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Job is the Schema for the bmcjobs API
+        description: Job is the Schema for the bmcjobs API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -37,44 +36,21 @@ spec:
           metadata:
             type: object
           spec:
-            description: JobSpec defines the desired state of Job
+            description: JobSpec defines the desired state of Job.
             properties:
               machineRef:
                 description: MachineRef represents the Machine resource to execute
                   the job. All the tasks in the job are executed for the same Machine.
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: Name of the Machine.
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: Namespace the Machine resides in.
                     type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
+                required:
+                - name
+                - namespace
                 type: object
               tasks:
                 description: Tasks represents a list of baseboard management actions
@@ -140,7 +116,7 @@ spec:
             - tasks
             type: object
           status:
-            description: JobStatus defines the observed state of Job
+            description: JobStatus defines the observed state of Job.
             properties:
               completionTime:
                 description: CompletionTime represents time when the job was completed.
@@ -179,9 +155,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tinkerbell/rufio/crds/bmc.tinkerbell.org_machines.yaml
+++ b/tinkerbell/rufio/crds/bmc.tinkerbell.org_machines.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: machines.bmc.tinkerbell.org
 spec:
   group: bmc.tinkerbell.org
@@ -20,7 +19,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Machine is the Schema for the machines API
+        description: Machine is the Schema for the machines API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -35,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: MachineSpec defines desired machine state
+            description: MachineSpec defines desired machine state.
             properties:
               connection:
                 description: Connection contains connection data for a Baseboard Management
@@ -44,17 +43,19 @@ spec:
                   authSecretRef:
                     description: AuthSecretRef is the SecretReference that contains
                       authentication information of the Machine. The Secret must contain
-                      username and password keys.
+                      username and password keys. This is optional as it is not required
+                      when using the RPC provider.
                     properties:
                       name:
-                        description: Name is unique within a namespace to reference
+                        description: name is unique within a namespace to reference
                           a secret resource.
                         type: string
                       namespace:
-                        description: Namespace defines the space within which the
+                        description: namespace defines the space within which the
                           secret name must be unique.
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   host:
                     description: Host is the host IP address or hostname of the Machine.
                     minLength: 1
@@ -66,17 +67,163 @@ spec:
                     default: 623
                     description: Port is the port number for connecting with the Machine.
                     type: integer
+                  providerOptions:
+                    description: ProviderOptions contains provider specific options.
+                    properties:
+                      intelAMT:
+                        description: IntelAMT contains the options to customize the
+                          IntelAMT provider.
+                        properties:
+                          port:
+                            description: Port that intelAMT will use for calls.
+                            type: integer
+                        required:
+                        - port
+                        type: object
+                      ipmitool:
+                        description: IPMITOOL contains the options to customize the
+                          Ipmitool provider.
+                        properties:
+                          cipherSuite:
+                            description: CipherSuite that ipmitool will use for calls.
+                            type: string
+                          port:
+                            description: Port that ipmitool will use for calls.
+                            type: integer
+                        type: object
+                      redfish:
+                        description: Redfish contains the options to customize the
+                          Redfish provider.
+                        properties:
+                          port:
+                            description: Port that redfish will use for calls.
+                            type: integer
+                        required:
+                        - port
+                        type: object
+                      rpc:
+                        description: RPC contains the options to customize the RPC
+                          provider.
+                        properties:
+                          consumerURL:
+                            description: ConsumerURL is the URL where an rpc consumer/listener
+                              is running and to which we will send and receive all
+                              notifications.
+                            type: string
+                          experimental:
+                            description: Experimental options.
+                            properties:
+                              customRequestPayload:
+                                description: CustomRequestPayload must be in json.
+                                type: string
+                              dotPath:
+                                description: 'DotPath is the path to the json object
+                                  where the bmclib RequestPayload{} struct will be
+                                  embedded. For example: object.data.body'
+                                type: string
+                            type: object
+                          hmac:
+                            description: HMAC is the options used to create a HMAC
+                              signature.
+                            properties:
+                              prefixSigDisabled:
+                                description: 'PrefixSigDisabled determines whether
+                                  the algorithm will be prefixed to the signature.
+                                  Example: sha256=abc123'
+                                type: boolean
+                              secrets:
+                                additionalProperties:
+                                  items:
+                                    description: SecretReference represents a Secret
+                                      Reference. It has enough information to retrieve
+                                      secret in any namespace
+                                    properties:
+                                      name:
+                                        description: name is unique within a namespace
+                                          to reference a secret resource.
+                                        type: string
+                                      namespace:
+                                        description: namespace defines the space within
+                                          which the secret name must be unique.
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                description: Secrets are a map of algorithms to secrets
+                                  used for signing.
+                                type: object
+                            type: object
+                          logNotificationsDisabled:
+                            description: LogNotificationsDisabled determines whether
+                              responses from rpc consumer/listeners will be logged
+                              or not.
+                            type: boolean
+                          request:
+                            description: Request is the options used to create the
+                              rpc HTTP request.
+                            properties:
+                              httpContentType:
+                                description: HTTPContentType is the content type to
+                                  use for the rpc request notification.
+                                type: string
+                              httpMethod:
+                                description: HTTPMethod is the HTTP method to use
+                                  for the rpc request notification.
+                                type: string
+                              staticHeaders:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: StaticHeaders are predefined headers
+                                  that will be added to every request.
+                                type: object
+                              timestampFormat:
+                                description: TimestampFormat is the time format for
+                                  the timestamp header.
+                                type: string
+                              timestampHeader:
+                                description: 'TimestampHeader is the header name that
+                                  should contain the timestamp. Example: X-BMCLIB-Timestamp'
+                                type: string
+                            type: object
+                          signature:
+                            description: Signature is the options used for adding
+                              an HMAC signature to an HTTP request.
+                            properties:
+                              appendAlgoToHeaderDisabled:
+                                description: 'AppendAlgoToHeaderDisabled decides whether
+                                  to append the algorithm to the signature header
+                                  or not. Example: X-BMCLIB-Signature becomes X-BMCLIB-Signature-256
+                                  When set to true, a header will be added for each
+                                  algorithm. Example: X-BMCLIB-Signature-256 and X-BMCLIB-Signature-512'
+                                type: boolean
+                              headerName:
+                                description: 'HeaderName is the header name that should
+                                  contain the signature(s). Example: X-BMCLIB-Signature'
+                                type: string
+                              includedPayloadHeaders:
+                                description: 'IncludedPayloadHeaders are headers whose
+                                  values will be included in the signature payload.
+                                  Example: X-BMCLIB-My-Custom-Header All headers will
+                                  be deduplicated.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        required:
+                        - consumerURL
+                        type: object
+                    type: object
                 required:
-                - authSecretRef
                 - host
                 - insecureTLS
-                - port
                 type: object
             required:
             - connection
             type: object
           status:
-            description: MachineStatus defines the observed state of Machine
+            description: MachineStatus defines the observed state of Machine.
             properties:
               conditions:
                 description: Conditions represents the latest available observations
@@ -109,6 +256,7 @@ spec:
                 enum:
                 - "on"
                 - "off"
+                - unknown
                 type: string
             type: object
         type: object
@@ -116,9 +264,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tinkerbell/rufio/crds/bmc.tinkerbell.org_tasks.yaml
+++ b/tinkerbell/rufio/crds/bmc.tinkerbell.org_tasks.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: tasks.bmc.tinkerbell.org
 spec:
   group: bmc.tinkerbell.org
@@ -45,17 +44,19 @@ spec:
                   authSecretRef:
                     description: AuthSecretRef is the SecretReference that contains
                       authentication information of the Machine. The Secret must contain
-                      username and password keys.
+                      username and password keys. This is optional as it is not required
+                      when using the RPC provider.
                     properties:
                       name:
-                        description: Name is unique within a namespace to reference
+                        description: name is unique within a namespace to reference
                           a secret resource.
                         type: string
                       namespace:
-                        description: Namespace defines the space within which the
+                        description: namespace defines the space within which the
                           secret name must be unique.
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   host:
                     description: Host is the host IP address or hostname of the Machine.
                     minLength: 1
@@ -67,11 +68,157 @@ spec:
                     default: 623
                     description: Port is the port number for connecting with the Machine.
                     type: integer
+                  providerOptions:
+                    description: ProviderOptions contains provider specific options.
+                    properties:
+                      intelAMT:
+                        description: IntelAMT contains the options to customize the
+                          IntelAMT provider.
+                        properties:
+                          port:
+                            description: Port that intelAMT will use for calls.
+                            type: integer
+                        required:
+                        - port
+                        type: object
+                      ipmitool:
+                        description: IPMITOOL contains the options to customize the
+                          Ipmitool provider.
+                        properties:
+                          cipherSuite:
+                            description: CipherSuite that ipmitool will use for calls.
+                            type: string
+                          port:
+                            description: Port that ipmitool will use for calls.
+                            type: integer
+                        type: object
+                      redfish:
+                        description: Redfish contains the options to customize the
+                          Redfish provider.
+                        properties:
+                          port:
+                            description: Port that redfish will use for calls.
+                            type: integer
+                        required:
+                        - port
+                        type: object
+                      rpc:
+                        description: RPC contains the options to customize the RPC
+                          provider.
+                        properties:
+                          consumerURL:
+                            description: ConsumerURL is the URL where an rpc consumer/listener
+                              is running and to which we will send and receive all
+                              notifications.
+                            type: string
+                          experimental:
+                            description: Experimental options.
+                            properties:
+                              customRequestPayload:
+                                description: CustomRequestPayload must be in json.
+                                type: string
+                              dotPath:
+                                description: 'DotPath is the path to the json object
+                                  where the bmclib RequestPayload{} struct will be
+                                  embedded. For example: object.data.body'
+                                type: string
+                            type: object
+                          hmac:
+                            description: HMAC is the options used to create a HMAC
+                              signature.
+                            properties:
+                              prefixSigDisabled:
+                                description: 'PrefixSigDisabled determines whether
+                                  the algorithm will be prefixed to the signature.
+                                  Example: sha256=abc123'
+                                type: boolean
+                              secrets:
+                                additionalProperties:
+                                  items:
+                                    description: SecretReference represents a Secret
+                                      Reference. It has enough information to retrieve
+                                      secret in any namespace
+                                    properties:
+                                      name:
+                                        description: name is unique within a namespace
+                                          to reference a secret resource.
+                                        type: string
+                                      namespace:
+                                        description: namespace defines the space within
+                                          which the secret name must be unique.
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                description: Secrets are a map of algorithms to secrets
+                                  used for signing.
+                                type: object
+                            type: object
+                          logNotificationsDisabled:
+                            description: LogNotificationsDisabled determines whether
+                              responses from rpc consumer/listeners will be logged
+                              or not.
+                            type: boolean
+                          request:
+                            description: Request is the options used to create the
+                              rpc HTTP request.
+                            properties:
+                              httpContentType:
+                                description: HTTPContentType is the content type to
+                                  use for the rpc request notification.
+                                type: string
+                              httpMethod:
+                                description: HTTPMethod is the HTTP method to use
+                                  for the rpc request notification.
+                                type: string
+                              staticHeaders:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: StaticHeaders are predefined headers
+                                  that will be added to every request.
+                                type: object
+                              timestampFormat:
+                                description: TimestampFormat is the time format for
+                                  the timestamp header.
+                                type: string
+                              timestampHeader:
+                                description: 'TimestampHeader is the header name that
+                                  should contain the timestamp. Example: X-BMCLIB-Timestamp'
+                                type: string
+                            type: object
+                          signature:
+                            description: Signature is the options used for adding
+                              an HMAC signature to an HTTP request.
+                            properties:
+                              appendAlgoToHeaderDisabled:
+                                description: 'AppendAlgoToHeaderDisabled decides whether
+                                  to append the algorithm to the signature header
+                                  or not. Example: X-BMCLIB-Signature becomes X-BMCLIB-Signature-256
+                                  When set to true, a header will be added for each
+                                  algorithm. Example: X-BMCLIB-Signature-256 and X-BMCLIB-Signature-512'
+                                type: boolean
+                              headerName:
+                                description: 'HeaderName is the header name that should
+                                  contain the signature(s). Example: X-BMCLIB-Signature'
+                                type: string
+                              includedPayloadHeaders:
+                                description: 'IncludedPayloadHeaders are headers whose
+                                  values will be included in the signature payload.
+                                  Example: X-BMCLIB-My-Custom-Header All headers will
+                                  be deduplicated.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        required:
+                        - consumerURL
+                        type: object
+                    type: object
                 required:
-                - authSecretRef
                 - host
                 - insecureTLS
-                - port
                 type: object
               task:
                 description: Task defines the specific action to be performed.
@@ -124,7 +271,7 @@ spec:
             - task
             type: object
           status:
-            description: TaskStatus defines the observed state of Task
+            description: TaskStatus defines the observed state of Task.
             properties:
               completionTime:
                 description: CompletionTime represents time when the task was completed.
@@ -162,9 +309,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.3.1
 - name: rufio
   repository: file://../rufio
-  version: 0.2.6
+  version: 0.2.7
 - name: hegel
   repository: file://../hegel
   version: 0.3.3
-digest: sha256:1b469b719c4d9cdf7fadb2fa2660a92dc27d0cce146de2f3d0034c722a83d25f
-generated: "2023-10-23T12:48:55.520524173-06:00"
+digest: sha256:bcb5e8d7e39ef085700ac3661500a5a8fd9f50ffff5b406d842e34c936e8c1e4
+generated: "2023-11-01T20:15:30.945845728-06:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.2"
+appVersion: "0.4.3"
 
 dependencies:
   - name: tink

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: "0.3.1"
     repository: "file://../smee"
   - name: rufio
-    version: "0.2.6"
+    version: "0.2.7"
     repository: "file://../rufio"
   - name: hegel
     version: "0.3.3"


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The CRD for Rufio were not updated to match the Rufio version. Even though the stack chart itself didn't change, we only create an OCI image for the stack chart. So this update to the Rufio chart necessitates a stack chart version bump.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
