### PR TITLE
stack: add dhcrelay giaddr control behaviour

### DIFF
--- a/tinkerbell/stack/README.md
+++ b/tinkerbell/stack/README.md
@@ -102,6 +102,7 @@ helm upgrade stack-release stack/ --namespace tink-system --wait
 | `stack.relay.image` | Image to use for the DHCP relay service | `ghcr.io/jacobweinstock/dhcrelay` |
 | `stack.relay.maxHopCount` | Maximum number of hops to allow for DHCP relay | `10` |
 | `stack.relay.sourceInterface` | Host/Node interface to use for listening for DHCP broadcast packets | `eno1` |
+| `stack.relay.presentGiaddrAction` | Control the handling of incoming DHCPv4 packets which already contain relay agent options | `append` |
 
 ### Tinkerbell Services Parameters
 

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -74,7 +74,7 @@ spec:
         {{- end }}
       - name: {{ .Values.stack.relay.name }}
         image: {{ .Values.stack.relay.image }}
-        args: ["-m", "append", "-c", "{{ .Values.stack.relay.maxHopCount }}", "-id", "{{ $macvlanInterfaceName }}", "-iu", "eth0", "-U", "eth0", "smee.{{ .Release.Namespace }}.svc.cluster.local."]
+        args: ["-m", "{{ .Values.stack.relay.presentGiaddrAction }}", "-c", "{{ .Values.stack.relay.maxHopCount }}", "-id", "{{ $macvlanInterfaceName }}", "-iu", "eth0", "-U", "eth0", "smee.{{ .Release.Namespace }}.svc.cluster.local."]
         ports:
         - containerPort: 67
           protocol: UDP

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -38,6 +38,12 @@ stack:
     # don't respect signals properly when run as PID 1.
     image: ghcr.io/jacobweinstock/dhcprelay # dhcprelay is a multiarch-enabled version of dhcrelay
     maxHopCount: 10
+    # The presentGiaddrAction pertains to the course of action when the giaddr field appears in the DHCP packet.
+    # In situations where another DHCP relay agent is already in operation within the environment,
+    # maintaining option (82) in its received state from the dhcrelay might be essential.
+    # This behavior can be regulated by configuring the presentGiaddrAction as "forward."
+    # Additional information is available at: https://linux.die.net/man/8/dhcrelay
+    presentGiaddrAction: append
     # sourceInterface is the Host/Node interface to use for listening for DHCP broadcast packets.
     # When unset, the interface from the default route will be used.
     # sourceInterface: eno1


### PR DESCRIPTION
## Description

Introduce presentGIAddr to control the handling of incoming DHCPv4 packets which already contain relay agent options.

## Why is this needed

When there are more relay agents - having append would result in multiple `Agent-Information`.