### PR TITLE
charts: stack: introduce stack.clusterDomain to replace hardcoded `cluster.local` values

### DIFF
--- a/tinkerbell/stack/templates/nginx-configmap.yaml
+++ b/tinkerbell/stack/templates/nginx-configmap.yaml
@@ -21,7 +21,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           resolver $POD_NAMESERVER;
-          set $smee_dns {{ .Values.smee.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
+          set $smee_dns {{ .Values.smee.name }}.{{ .Release.Namespace }}.svc.{{ .Values.stack.clusterDomain }}.; # needed in Kubernetes for dynamic DNS resolution
 
           proxy_pass http://$smee_dns:{{ .Values.smee.http.port }};
         }
@@ -33,7 +33,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           resolver $POD_NAMESERVER;
-          set $hegel_dns {{ .Values.hegel.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
+          set $hegel_dns {{ .Values.hegel.name }}.{{ .Release.Namespace }}.svc.{{ .Values.stack.clusterDomain }}.; # needed in Kubernetes for dynamic DNS resolution
 
           proxy_pass http://$hegel_dns:{{ .Values.hegel.service.port }};
         }
@@ -46,7 +46,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           resolver $POD_NAMESERVER;
-          set $tink_dns {{ .Values.tink.server.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
+          set $tink_dns {{ .Values.tink.server.name }}.{{ .Release.Namespace }}.svc.{{ .Values.stack.clusterDomain }}.; # needed in Kubernetes for dynamic DNS resolution
 
           grpc_pass grpc://$tink_dns:{{ .Values.tink.server.service.port }};
         }
@@ -68,14 +68,14 @@ data:
       server {
           listen {{ .Values.smee.tftp.port }} udp;
           resolver $POD_NAMESERVER;
-          set $smee_dns {{ .Values.smee.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
+          set $smee_dns {{ .Values.smee.name }}.{{ .Release.Namespace }}.svc.{{ .Values.stack.clusterDomain }}.; # needed in Kubernetes for dynamic DNS resolution
           proxy_pass $smee_dns:{{ .Values.smee.tftp.port }};
           access_log /dev/stdout logger-json;
       }
       server {
           listen {{ .Values.smee.syslog.port }} udp;
           resolver $POD_NAMESERVER;
-          set $smee_dns {{ .Values.smee.name }}.{{ .Release.Namespace }}.svc.cluster.local.; # needed in Kubernetes for dynamic DNS resolution
+          set $smee_dns {{ .Values.smee.name }}.{{ .Release.Namespace }}.svc.{{ .Values.stack.clusterDomain }}.; # needed in Kubernetes for dynamic DNS resolution
           proxy_pass $smee_dns:{{ .Values.smee.syslog.port }};
           access_log /dev/stdout logger-json;
       }

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -74,7 +74,7 @@ spec:
         {{- end }}
       - name: {{ .Values.stack.relay.name }}
         image: {{ .Values.stack.relay.image }}
-        args: ["-m", "{{ .Values.stack.relay.presentGiaddrAction }}", "-c", "{{ .Values.stack.relay.maxHopCount }}", "-id", "{{ $macvlanInterfaceName }}", "-iu", "eth0", "-U", "eth0", "smee.{{ .Release.Namespace }}.svc.cluster.local."]
+        args: ["-m", "{{ .Values.stack.relay.presentGiaddrAction }}", "-c", "{{ .Values.stack.relay.maxHopCount }}", "-id", "{{ $macvlanInterfaceName }}", "-iu", "eth0", "-U", "eth0", "smee.{{ .Release.Namespace }}.svc.{{ .Values.stack.clusterDomain }}."]
         ports:
         - containerPort: 67
           protocol: UDP

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -6,6 +6,8 @@ stack:
     type: LoadBalancer
   selector:
     app: tink-stack
+  # stack needs to resolve DNS names in the cluster (in .svc.clusterDomain)
+  clusterDomain: cluster.local
   # &publicIP is a YAML anchor. It allows us to define a value once and reference it multiple times.
   # https://helm.sh/docs/chart_template_guide/yaml_techniques/#yaml-anchors
   loadBalancerIP: &publicIP 192.168.2.112


### PR DESCRIPTION
#### charts: stack: introduce stack.clusterDomain to replace hardcoded `cluster.local` values

## Description

Use a value instead of `cluster.local` hardcoded in a few places.

## Why is this needed

Some clusters might not have cluster.local domain, although it is the default.
