### PR TITLE
stack: introduce hook.downloadEnabled boolean to include/exclude hook download job

### DIFF
--- a/tinkerbell/stack/templates/hook.yaml
+++ b/tinkerbell/stack/templates/hook.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.stack.hook.enabled }}
+{{- if .Values.stack.hook.downloadEnabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -39,7 +40,7 @@ spec:
       containers:
         - name: download-hook
           image: {{ .Values.stack.hook.image }}
-          command: ["/script/entrypoint.sh"]
+          command: [ "/script/entrypoint.sh" ]
           volumeMounts:
             - mountPath: /output
               name: hook-artifacts
@@ -55,4 +56,5 @@ spec:
           configMap:
             defaultMode: 0700
             name: download-hook
+{{- end }}
 {{- end }}

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -23,6 +23,7 @@ stack:
     # downloadURL only works with the > 0.8.1 Hook release because
     # previous Hook versions didn't provide a checksum file.
     downloadURL: https://github.com/tinkerbell/hook/releases/download/latest
+    downloadEnabled: true # Set to false if you somehow download Hook manually; if set to True will include a download Job
   kubevip:
     enabled: true
     name: kube-vip


### PR DESCRIPTION
#### stack: introduce hook.downloadEnabled boolean to include/exclude hook download job

- sometimes we don't want to download the default hook binaries
- this is separate from stack.hook.enabled, which controls the hostPath etc

