### PR TITLE
stack: introduce relay.macvlanIntfNumber to avoid using random number

### DIFF
--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.stack.enabled }}
 {{- $sourceInterface := .Values.stack.relay.sourceInterface -}}
-{{- $macvlanInterfaceName := printf "%s%s" "macvlan" (randNumeric 2) -}}
+{{- $macvlanInterfaceName := printf "%s%s" "macvlan" (.Values.stack.relay.macvlanIntfNumber | default (randNumeric 2)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -49,6 +49,7 @@ stack:
     # sourceInterface is the Host/Node interface to use for listening for DHCP broadcast packets.
     # When unset, the interface from the default route will be used.
     # sourceInterface: eno1
+    macvlanIntfNumber: null # string! if unset, will use a random interface number, which will cause each Helm deploy to restart the relay
     # TODO(jacobweinstock): add feature to be able to disable listening for broadcast traffic.
 
 # -- Overrides


### PR DESCRIPTION
#### stack: introduce relay.macvlanIntfNumber to avoid using random number

- if unset, still uses the random
- using random causes restarts on every Helm deploy
