### PR TITLE
tinkerbell/charts: introduce `showcase` chart

### DIFF
--- a/tinkerbell/showcase/Chart.yaml
+++ b/tinkerbell/showcase/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: showcase
+description: Generates Tinkerbell CR's for a plethora of standard and exotic hardware; downloads & prepares Hook and OS images for provisioning
+type: application
+version: "0.0.1"
+

--- a/tinkerbell/showcase/Chart.yaml
+++ b/tinkerbell/showcase/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: showcase
 description: Generates Tinkerbell CR's for a plethora of standard and exotic hardware; downloads & prepares Hook and OS images for provisioning
 type: application
-version: "0.0.1"
+version: "0.0.2"
 

--- a/tinkerbell/showcase/README.md
+++ b/tinkerbell/showcase/README.md
@@ -1,0 +1,31 @@
+#### tinkerbell/charts: introduce `showcase` chart
+
+- `showcase` is a chart that, based on values.yaml dictionaries:
+    - generates Tinkerbell CRs (Hardware/Template/Workflow) for both standard (UEFI) & exotic (supported by Armbian) devices
+    - generates download/process jobs for multiple Hook flavors (see https://github.com/tinkerbell/hook/pull/205)
+    - generates download/process jobs for a few OS images (Ubuntu Cloud Images, Armbian, etc)
+    - should be independent of how one deployed Tinkerbell itself (stack chart, individual components, etc)
+- A few features:
+    - validates values.yaml for common mistakes; arch must match, etc.
+    - validates & handles rootDisk differences (re-invents "formatPartition()" a bit)
+    - avoids re-downloading Hooks and Images that are already on disk, even if Job re-runs
+    - allows easy way to use
+        - custom Hooks
+        - custom Kernel cmdline parameters at both the Hook & device level
+            - for example `acpi=off` at Hook level and `console=ttyS0` at board level
+        - custom OS images for deployment
+        - reboot or kexec to finish deployment
+        - different partition numbers for OS image's rootfs (some images have ESP, some have a separate `/boot`, etc)
+        - control if growpart and/or ssh/user setup is done during provisioning or not
+        - conversion of OS images (`qemu-to-raw-gzip` and `xz-to-gz`)
+    - has a "merge" mechanism with a common way to set parameters like net gateway, UEFI, etc (also easy to override per-device)
+    - default values have everything `enabled: false` thus showcase should produce nothing by default.
+        - Hooks & Images can be forced `enabled: true` in values.yaml, or
+            - `enabled: true` Devices automatically enable their Hook & Image
+- Probably missing:
+    - More validations
+    - Currently pointing to my Tinkerbell Actions, which I haven't PR'ed yet
+- How to use:
+    - Clone it, edit the values.yaml to your liking, and deploy.
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -1,0 +1,251 @@
+{{- range $deviceId, $dev := .Values.hardware.devices }}
+
+{{- if not $dev.enabled }}
+# Device not enabled: {{$deviceId}}
+{{- else }}
+# Device enabled: {{$deviceId}}
+{{- $common := $.Values.hardware.common -}}
+{{- $mergedDevice := merge $dev $common }}
+{{- $hookObj := index $.Values.provision.hook $mergedDevice.hookRef }}
+{{- if not $hookObj }}{{- fail (printf "Device '%s', hookRef '%s': %s" $deviceId $mergedDevice.hookRef "hookRef not found") }}{{- end }}
+{{- $imageObj := index $.Values.provision.images $mergedDevice.imageRef }}
+{{- if not $imageObj }}{{- (printf "Device '%s', imageRef '%s': %s" $deviceId $mergedDevice.imageRef "imageRef not found") }}{{- end }}
+# Check sanity of arch across device / image / hook - they all must match
+# Device arch: {{$dev.arch}} Image arch: {{$imageObj.arch}} Hook arch: {{$hookObj.arch}}
+{{- if ne $imageObj.arch $hookObj.arch }}{{- fail (printf "Device '%s': '%s'" $deviceId "image and hook arch mismatch") }}{{- end }}
+{{- if ne $dev.arch $imageObj.arch }}{{- fail (printf "Device '%s': '%s'" $deviceId "device and image arch mismatch") }}{{- end }}
+{{- if ne $dev.arch $hookObj.arch }}{{- fail (printf "Device '%s': '%s'" $deviceId "device and hook arch mismatch") }}{{- end }}
+{{- $rootDiskDevice := required (printf "Device '%s' - %s" $deviceId "rootDisk is required") $mergedDevice.rootDisk }}
+{{- if not (hasPrefix "/dev" $rootDiskDevice) }}{{- fail (printf "Device '%s' (rootDisk '%s'): '%s'" $deviceId $rootDiskDevice "rootDisk does not begin with /dev") }}{{- end }}
+{{- $rootDiskRootfsPartitionNumber := printf "%s" $imageObj.rootfsPartitionNumber }}
+  # rootDiskRootfsPartitionNumber is {{$rootDiskRootfsPartitionNumber}}
+{{- $rootDiskRootfsPartitionDevice := "unknown" }}
+
+{{- if hasPrefix "/dev/disk/" $rootDiskDevice }}
+  # YES! {{$rootDiskDevice}} begins with /dev/disk
+{{- $rootDiskRootfsPartitionDevice = printf "%s-part%s" $rootDiskDevice $rootDiskRootfsPartitionNumber  }}
+{{- else }}
+  # NO! {{$rootDiskDevice}} does not begin with /dev/disk
+{{- if regexMatch "[0-9]$" $rootDiskDevice }}
+  # YES! {{$rootDiskDevice}} ends with a digit - REGEX MATCH
+{{- $rootDiskRootfsPartitionDevice = printf "%sp%s" $rootDiskDevice $rootDiskRootfsPartitionNumber  }}
+{{- else }}
+  # NO! {{$rootDiskDevice}} does not end with a digit - REGEX NOT MATCH
+{{- $rootDiskRootfsPartitionDevice = printf "%s%s" $rootDiskDevice $rootDiskRootfsPartitionNumber  }}
+{{- end }}
+{{- end }}
+  # Thus at the end of the day, $rootDiskRootfsPartitionDevice is {{$rootDiskRootfsPartitionDevice}}
+---
+apiVersion: "tinkerbell.org/v1alpha1"
+kind: Hardware
+metadata:
+  name: "{{ $deviceId }}-hardware"
+  labels:
+    "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+    "app.kubernetes.io/part-of": "tinkerbell-showcase"
+spec:
+  disks:
+    - device: "{{ $rootDiskDevice }}"
+  metadata:
+    facility:
+      facility_code: sandbox
+    instance:
+      hostname: "{{ $deviceId }}"
+      id: "{{ $dev.mac }}"
+      operating_system:
+        distro: "ubuntu" # @TODO
+        os_slug: "ubuntu_20_04"
+        version: "20.04"
+  interfaces:
+    - dhcp:
+        arch: "{{ $dev.arch }}"
+        hostname: "{{ $deviceId }}"
+        ip:
+          address: "{{ $dev.ipv4.address }}"
+          netmask: "{{ $dev.ipv4.netmask }}"
+          gateway: "{{ $dev.ipv4.gateway }}"
+        lease_time: 86400
+        mac: "{{ $dev.mac }}"
+        name_servers:
+          {{- range $mergedDevice.ipv4.dns }}
+          - {{ . | quote }}
+          {{- end }}
+        uefi: {{ $dev.uefi }}
+      netboot:
+        allowPXE: true
+        allowWorkflow: true
+        ipxe: # @TODO
+          contents: |
+            echo Showcase starting for {{$deviceId}} with hook {{$mergedDevice.hookRef}} and image {{$mergedDevice.imageRef}}...
+            set download-url {{ $.Values.tinkerbell.hookURL }}
+            set kernel-params tink_worker_image=quay.io/tinkerbell/tink-worker:latest facility= syslog_host={{ $.Values.tinkerbell.syslogHost }} grpc_authority={{ $.Values.tinkerbell.grpcAuthority }} tinkerbell_tls=false worker_id={{$dev.mac}} hw_addr={{$dev.mac}} modules=loop,squashfs,sd-mod,usb-storage initrd={{ $hookObj.initrd }} {{$hookObj.kernelCommandLine}} {{ $dev.extraKernelCommandLine }}
+            echo Kernel image: ${download-url}/{{ $hookObj.kernel }}
+            echo Kernel initrd: ${download-url}/{{ $hookObj.initrd }}
+            echo Kernel cmdline: ${kernel-params}
+            kernel ${download-url}/{{ $hookObj.kernel }} ${kernel-params}
+            initrd ${download-url}/{{ $hookObj.initrd }}
+            boot
+---
+apiVersion: "tinkerbell.org/v1alpha1"
+kind: Template
+metadata:
+  name: "{{ $deviceId }}-template"
+  labels:
+    "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+    "app.kubernetes.io/part-of": "tinkerbell-showcase"
+spec:
+  data: |
+    version: "0.1"
+    name: "{{ $deviceId }}-template"
+    global_timeout: 1800
+    tasks:
+      - name: "os-installation-{{ $deviceId }}"
+        worker: "{{ $dev.mac }}"
+        volumes:
+          - /dev:/dev
+          - /dev/console:/dev/console
+          - /lib/firmware:/lib/firmware:ro
+
+        actions:
+          - name: "stream-ubuntu-image-{{ $deviceId }}"
+            #image: quay.io/tinkerbell-actions/image2disk:v1.0.0
+            image: {{ $.Values.actions.repository }}/image2disk:{{ $.Values.actions.version }}
+            timeout: 600
+            environment:
+              DEST_DISK: "{{ $rootDiskDevice }}"
+              IMG_URL: "{{ $.Values.tinkerbell.imagesURL }}/{{ $imageObj.image }}"
+              COMPRESSED: true
+
+          {{- if $imageObj.doGrowPart }}
+          - name: "grow-partition-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              BLOCK_DEVICE: {{ $rootDiskRootfsPartitionDevice }}
+              FS_TYPE: ext4
+              CHROOT: y
+              DEFAULT_INTERPRETER: "/bin/sh -c"
+              CMD_LINE: "growpart {{ $rootDiskDevice }} {{$rootDiskRootfsPartitionNumber}} && resize2fs {{$rootDiskRootfsPartitionDevice}}"
+          {{- end }}
+
+          - name: "fix-resolv-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              CHROOT: y
+              DEFAULT_INTERPRETER: "/bin/sh -c"
+              CMD_LINE: "echo 'list /etc/resolv.conf: '; ls -la /etc/resolv.conf; echo 'cat /etc/resolv.conf'; cat /etc/resolv.conf; echo 'moving...'; mv -v /etc/resolv.conf /etc/resolv.conf.orig.tink; echo 'nameserver {{ index $mergedDevice.ipv4.dns 0 }} ' > /etc/resolv.conf; echo 'new resolf.conf:' ; cat /etc/resolv.conf"
+
+
+          {{- if $imageObj.doUserAndSshSetup }}
+          - name: "install-openssl-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              CHROOT: y
+              DEFAULT_INTERPRETER: "/bin/sh -c"
+              CMD_LINE: "apt -y update && apt -y install openssl"
+          - name: "create-user-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              CHROOT: y
+              DEFAULT_INTERPRETER: "/bin/sh -c"
+              CMD_LINE: "useradd -p $(openssl passwd -1 tink) -s /bin/bash -d /home/tink/ -m -G sudo tink"
+          - name: "enable-ssh-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              CHROOT: y
+              DEFAULT_INTERPRETER: "/bin/sh -c"
+              CMD_LINE: "ssh-keygen -A; systemctl enable ssh.service; echo 'PasswordAuthentication yes' > /etc/ssh/sshd_config.d/60-cloudimg-settings.conf"
+          - name: "disable-apparmor-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              CHROOT: y
+              DEFAULT_INTERPRETER: "/bin/sh -c"
+              CMD_LINE: "systemctl disable apparmor; systemctl disable snapd"
+          - name: "write-netplan-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/writefile:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              DEST_DISK: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              DEST_PATH: /etc/netplan/config.yaml
+              CONTENTS: |
+                network:
+                  version: 2
+                  renderer: networkd
+                  ethernets:
+                    id0:
+                      match:
+                        name: en*
+                      dhcp4: true
+              UID: 0
+              GID: 0
+              MODE: 0644
+              DIRMODE: 0755
+          {{- end }}
+
+          - name: "revert-fix-resolv-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              CHROOT: y
+              DEFAULT_INTERPRETER: "/bin/sh -c"
+              CMD_LINE: "rm -v /etc/resolv.conf; mv -v /etc/resolv.conf.orig.tink /etc/resolv.conf"
+
+          {{- if eq $hookObj.bootMode "kexec" }}
+          - name: "kexec-{{ $deviceId }}"
+            image: ghcr.io/jacobweinstock/waitdaemon:latest
+            timeout: 90
+            pid: host
+            environment:
+              BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              IMAGE: {{ $.Values.actions.repository }}/kexec:{{ $.Values.actions.version }}
+              WAIT_SECONDS: 1
+            volumes:
+              - /var/run/docker.sock:/var/run/docker.sock
+          {{- end }}
+
+          {{- if eq $hookObj.bootMode "reboot" }}
+          - name: "reboot-{{ $deviceId }}"
+            image: ghcr.io/jacobweinstock/waitdaemon:latest
+            timeout: 90
+            pid: host
+            command: ["reboot"]
+            environment:
+              IMAGE: alpine
+              WAIT_SECONDS: 1
+            volumes:
+              - /var/run/docker.sock:/var/run/docker.sock
+          {{- end }}
+---
+apiVersion: "tinkerbell.org/v1alpha1"
+kind: Workflow
+metadata:
+  name: "{{ $deviceId }}-workflow"
+  labels:
+    "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+    "app.kubernetes.io/part-of": "tinkerbell-showcase"
+spec:
+  templateRef: "{{ $deviceId }}-template"
+  hardwareRef: "{{ $deviceId }}-hardware"
+  hardwareMap:
+    device_1: "{{ $dev.mac }}"
+{{- end }}
+{{- end }}

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -6,6 +6,8 @@
 # Device enabled: {{$deviceId}}
 {{- $common := $.Values.hardware.common -}}
 {{- $mergedDevice := merge $dev $common }}
+# Getting hook from hookRef: '{{$mergedDevice.hookRef}}'
+{{- if not $mergedDevice.hookRef }}{{- fail (printf "Device '%s', hookRef '%s': %s" $deviceId $mergedDevice.hookRef "hookRef unset?") }}{{- end }}
 {{- $hookObj := index $.Values.provision.hook $mergedDevice.hookRef }}
 {{- if not $hookObj }}{{- fail (printf "Device '%s', hookRef '%s': %s" $deviceId $mergedDevice.hookRef "hookRef not found") }}{{- end }}
 {{- $imageObj := index $.Values.provision.images $mergedDevice.imageRef }}

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -130,6 +130,7 @@ spec:
               CMD_LINE: "growpart {{ $rootDiskDevice }} {{$rootDiskRootfsPartitionNumber}} && resize2fs {{$rootDiskRootfsPartitionDevice}}"
           {{- end }}
 
+          {{- if ($imageObj.doFixResolvConf)  }}
           - name: "fix-resolv-{{ $deviceId }}"
             image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
             timeout: 90
@@ -139,6 +140,7 @@ spec:
               CHROOT: y
               DEFAULT_INTERPRETER: "/bin/sh -c"
               CMD_LINE: "echo 'list /etc/resolv.conf: '; ls -la /etc/resolv.conf; echo 'cat /etc/resolv.conf'; cat /etc/resolv.conf; echo 'moving...'; mv -v /etc/resolv.conf /etc/resolv.conf.orig.tink; echo 'nameserver {{ index $mergedDevice.ipv4.dns 0 }} ' > /etc/resolv.conf; echo 'new resolf.conf:' ; cat /etc/resolv.conf"
+          {{- end }}
 
 
           {{- if $imageObj.doUserAndSshSetup }}
@@ -200,6 +202,7 @@ spec:
               DIRMODE: 0755
           {{- end }}
 
+          {{- if ($imageObj.doFixResolvConf )  }}
           - name: "revert-fix-resolv-{{ $deviceId }}"
             image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
             timeout: 90
@@ -209,6 +212,7 @@ spec:
               CHROOT: y
               DEFAULT_INTERPRETER: "/bin/sh -c"
               CMD_LINE: "rm -v /etc/resolv.conf; mv -v /etc/resolv.conf.orig.tink /etc/resolv.conf"
+          {{- end }}
 
           {{- if eq $hookObj.bootMode "kexec" }}
           - name: "kexec-{{ $deviceId }}"

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -58,16 +58,23 @@ metadata:
 spec:
   disks:
     - device: "{{ $rootDiskDevice }}"
+  userData: |
+    {{- $mergedDevice.userData | default "echo 'tinkerbell-showcase: userData not configured for device';" | nindent 4 }}
   metadata:
     facility:
-      facility_code: sandbox
+      facility_code: tinkerbell-showcase
+      plan_slug: "{{$deviceId}}"
     instance:
       hostname: "{{ $deviceId }}"
       id: "{{ $dev.mac }}"
+      tags:
+        - "tinkerbell-showcase"
       operating_system:
         distro: "ubuntu" # @TODO
-        os_slug: "ubuntu_20_04"
-        version: "20.04"
+        image_tag: "latest"
+        slug: "ubuntuslug"
+        os_slug: "ubuntu_24_04"
+        version: "24.04"
   interfaces:
     - dhcp:
         arch: "{{ $dev.arch }}"
@@ -211,6 +218,43 @@ spec:
               GID: 0
               MODE: 0644
               DIRMODE: 0755
+          {{- end }}
+
+          {{- if ($imageObj.doInjectHegelCloudInit )  }}
+          # Based on https://tinkerbell.org/docs/integrations/cloudinit/#setup-cloud-init-to-use-hegel
+          - name: "inject-cloud-init-hegel-cfg-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/writefile:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
+              CONTENTS: |
+                datasource:
+                  Ec2:
+                    metadata_urls: ["{{ $.Values.tinkerbell.hegelURL }}"]
+                    strict_id: false
+                manage_etc_hosts: localhost
+                warnings:
+                  dsid_missing_source: off      
+              DEST_DISK: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              UID: 0
+              GID: 0
+              MODE: 0600
+              DIRMODE: 0700
+
+          - name: "inject-cloud-init-hegel-ds-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/writefile:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              DEST_PATH: /etc/cloud/ds-identify.cfg
+              CONTENTS: |
+                datasource: Ec2
+              DEST_DISK: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              UID: 0
+              GID: 0
+              MODE: 0600
+              DIRMODE: 0700
           {{- end }}
 
           {{- if ($imageObj.doFixResolvConf )  }}

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -192,7 +192,7 @@ spec:
                   ethernets:
                     id0:
                       match:
-                        name: en*
+                        name: e*
                       dhcp4: true
               UID: 0
               GID: 0

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -59,7 +59,7 @@ spec:
   disks:
     - device: "{{ $rootDiskDevice }}"
   userData: |
-    {{- $mergedDevice.userData | default "echo 'tinkerbell-showcase: userData not configured for device';" | nindent 4 }}
+    {{- $mergedDevice.userData | default "#!/bin/bash\necho 'tinkerbell-showcase: userData not configured for device' >&2;" | nindent 4 }}
   metadata:
     facility:
       facility_code: tinkerbell-showcase

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -275,7 +275,7 @@ spec:
 
           {{- if eq $hookObj.bootMode "kexec" }}
           - name: "kexec-{{ $deviceId }}"
-            image: ghcr.io/jacobweinstock/waitdaemon:latest
+            image: {{ $.Values.actions.repository }}/waitdaemon:{{ $.Values.actions.version }}
             timeout: 90
             pid: host
             environment:
@@ -289,7 +289,7 @@ spec:
 
           {{- if eq $hookObj.bootMode "reboot" }}
           - name: "reboot-{{ $deviceId }}"
-            image: ghcr.io/jacobweinstock/waitdaemon:latest
+            image: {{ $.Values.actions.repository }}/waitdaemon:{{ $.Values.actions.version }}
             timeout: 90
             pid: host
             command: ["reboot"]

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -32,21 +32,26 @@
 {{- $rootDiskRootfsPartitionNumber := printf "%s" $imageObj.rootfsPartitionNumber }}
   # rootDiskRootfsPartitionNumber is {{$rootDiskRootfsPartitionNumber}}
 {{- $rootDiskRootfsPartitionDevice := "unknown" }}
+{{- $espPartitionDevice := "unknown" }}
+{{- $espPartitionNumber := "1" }}
 
 {{- if hasPrefix "/dev/disk/" $rootDiskDevice }}
   # YES! {{$rootDiskDevice}} begins with /dev/disk
 {{- $rootDiskRootfsPartitionDevice = printf "%s-part%s" $rootDiskDevice $rootDiskRootfsPartitionNumber  }}
+{{- $espPartitionDevice = printf "%s-part%s" $rootDiskDevice $espPartitionNumber  }}
 {{- else }}
   # NO! {{$rootDiskDevice}} does not begin with /dev/disk
 {{- if regexMatch "[0-9]$" $rootDiskDevice }}
   # YES! {{$rootDiskDevice}} ends with a digit - REGEX MATCH
 {{- $rootDiskRootfsPartitionDevice = printf "%sp%s" $rootDiskDevice $rootDiskRootfsPartitionNumber  }}
+{{- $espPartitionDevice = printf "%sp%s" $rootDiskDevice $espPartitionNumber  }}
 {{- else }}
   # NO! {{$rootDiskDevice}} does not end with a digit - REGEX NOT MATCH
 {{- $rootDiskRootfsPartitionDevice = printf "%s%s" $rootDiskDevice $rootDiskRootfsPartitionNumber  }}
+{{- $espPartitionDevice = printf "%s%s" $rootDiskDevice $espPartitionNumber  }}
 {{- end }}
 {{- end }}
-  # Thus at the end of the day, $rootDiskRootfsPartitionDevice is {{$rootDiskRootfsPartitionDevice}}
+  # Thus at the end of the day, $rootDiskRootfsPartitionDevice is {{$rootDiskRootfsPartitionDevice}} and ESP is {{$espPartitionDevice}}
 ---
 apiVersion: "tinkerbell.org/v1alpha1"
 kind: Hardware
@@ -282,7 +287,19 @@ spec:
               FS_TYPE: ext4
               CHROOT: y
               DEFAULT_INTERPRETER: "/bin/bash -c"
-              CMD_LINE: "set -x; mount; lsblk; blkid; mount -o remount,rw /sys; mount -t efivarfs none /sys/firmware/efi/efivars; mount; efibootmgr --verbose; efibootmgr --create --disk '{{ $rootDiskDevice }}' --label PROViSiONED; efibootmgr --verbose"
+              CMD_LINE: "set -x; mount; lsblk; blkid; mount -o remount,rw /sys; mount -t efivarfs none /sys/firmware/efi/efivars; mount; efibootmgr --verbose; efibootmgr --create --disk '{{ $rootDiskDevice }}' --label PROViSiONED; efibootmgr --verbose; umount /sys/firmware/efi/efivars; sync"
+          {{- end }}
+
+          {{- if ($imageObj.doRestoreGRUBNormalcy )  }}
+          - name: "restore-grub-normalcy-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              CHROOT: y
+              DEFAULT_INTERPRETER: "/bin/bash -c"
+              CMD_LINE: "set -x; mount; lsblk; blkid; mount -o remount,rw /sys; mount -t efivarfs none /sys/firmware/efi/efivars; mount '{{ $espPartitionDevice }}' /boot; mount; rm -rfv /boot/ubuntu /boot/loader /boot/EFI; mkdir -pv /boot/EFI; update-initramfs -k all -c; echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"${GRUB_CMDLINE_LINUX_DEFAULT} {{$mergedDevice.extraKernelCommandLine}}\"' > /etc/default/grub.d/60-provisioned.cfg; cat /etc/default/grub.d/60-provisioned.cfg; mv -v /etc/os-release /etc/os-release.hold; echo 'NAME={{$mergedDevice.imageRef}}' > /etc/os-release; grub-install --efi-directory /boot '--bootloader-id={{$mergedDevice.imageRef}}'; update-grub; tree /boot; cat /boot/grub/grub.cfg; efibootmgr --verbose; umount /sys/firmware/efi/efivars; umount /boot; mv -v /etc/os-release.hold /etc/os-release; sync"
           {{- end }}
 
           {{- if eq $hookObj.bootMode "kexec" }}

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -86,6 +86,7 @@ spec:
             echo Kernel cmdline: ${kernel-params}
             kernel ${download-url}/{{ $hookObj.kernel }} ${kernel-params}
             initrd ${download-url}/{{ $hookObj.initrd }}
+            imgstat
             boot
 ---
 apiVersion: "tinkerbell.org/v1alpha1"

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -90,6 +90,10 @@ spec:
           - {{ . | quote }}
           {{- end }}
         uefi: {{ $dev.uefi }}
+        time_servers:
+          {{- range $mergedDevice.ipv4.time_servers }}
+          - {{ . | quote }}
+          {{- end }}
       netboot:
         allowPXE: true
         allowWorkflow: true

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -142,15 +142,15 @@ spec:
 
 
           {{- if $imageObj.doUserAndSshSetup }}
-          - name: "install-openssl-{{ $deviceId }}"
+          - name: "install-packages-{{ $deviceId }}"
             image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
-            timeout: 90
+            timeout: 180 # 3 minutes
             environment:
               BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
               FS_TYPE: ext4
               CHROOT: y
               DEFAULT_INTERPRETER: "/bin/sh -c"
-              CMD_LINE: "apt -y update && apt -y install openssl"
+              CMD_LINE: "apt -y update && DEBIAN_FRONTEND=noninteractive apt -y install openssl neofetch --no-install-recommends --no-install-suggests"
           - name: "create-user-{{ $deviceId }}"
             image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
             timeout: 90

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -273,6 +273,18 @@ spec:
               CMD_LINE: "rm -v /etc/resolv.conf; mv -v /etc/resolv.conf.orig.tink /etc/resolv.conf"
           {{- end }}
 
+          {{- if ($imageObj.doAddEFIBootEntry )  }}
+          - name: "add-efi-boot-entry-{{ $deviceId }}"
+            image: {{ $.Values.actions.repository }}/cexec:{{ $.Values.actions.version }}
+            timeout: 90
+            environment:
+              BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
+              FS_TYPE: ext4
+              CHROOT: y
+              DEFAULT_INTERPRETER: "/bin/bash -c"
+              CMD_LINE: "set -x; mount; lsblk; blkid; mount -o remount,rw /sys; mount -t efivarfs none /sys/firmware/efi/efivars; mount; efibootmgr --verbose; efibootmgr --create --disk '{{ $rootDiskDevice }}' --label PROViSiONED; efibootmgr --verbose"
+          {{- end }}
+
           {{- if eq $hookObj.bootMode "kexec" }}
           - name: "kexec-{{ $deviceId }}"
             image: {{ $.Values.actions.repository }}/waitdaemon:{{ $.Values.actions.version }}

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -1,19 +1,29 @@
 {{- range $deviceId, $dev := .Values.hardware.devices }}
 
 {{- if not $dev.enabled }}
-# Device not enabled: {{$deviceId}}
+  # Device not enabled: {{$deviceId}}
 {{- else }}
-# Device enabled: {{$deviceId}}
+  # Device enabled: {{$deviceId}}
 {{- $common := $.Values.hardware.common -}}
 {{- $mergedDevice := merge $dev $common }}
-# Getting hook from hookRef: '{{$mergedDevice.hookRef}}'
+  # Getting hook from hookRef: '{{$mergedDevice.hookRef}}'
 {{- if not $mergedDevice.hookRef }}{{- fail (printf "Device '%s', hookRef '%s': %s" $deviceId $mergedDevice.hookRef "hookRef unset?") }}{{- end }}
+
 {{- $hookObj := index $.Values.provision.hook $mergedDevice.hookRef }}
 {{- if not $hookObj }}{{- fail (printf "Device '%s', hookRef '%s': %s" $deviceId $mergedDevice.hookRef "hookRef not found") }}{{- end }}
+  # if the device has a hookOverride property, merge it on top of the hookObj; pre-merge: {{$hookObj.bootMode}}
+{{ if $mergedDevice.hookOverride }}
+  # YES!!!!!!!!!! has hookOverride {{$deviceId}}
+{{ $hookObj = merge $mergedDevice.hookOverride $hookObj }}
+{{ else }}
+  # NO!!!!!!!!!! no hookOverride {{$deviceId}}
+{{ end }}
+  # Reboot mode after merge: {{$hookObj.bootMode}}
+
 {{- $imageObj := index $.Values.provision.images $mergedDevice.imageRef }}
 {{- if not $imageObj }}{{- (printf "Device '%s', imageRef '%s': %s" $deviceId $mergedDevice.imageRef "imageRef not found") }}{{- end }}
-# Check sanity of arch across device / image / hook - they all must match
-# Device arch: {{$dev.arch}} Image arch: {{$imageObj.arch}} Hook arch: {{$hookObj.arch}}
+  # Check sanity of arch across device / image / hook - they all must match
+  # Device arch: {{$dev.arch}} Image arch: {{$imageObj.arch}} Hook arch: {{$hookObj.arch}}
 {{- if ne $imageObj.arch $hookObj.arch }}{{- fail (printf "Device '%s': '%s'" $deviceId "image and hook arch mismatch") }}{{- end }}
 {{- if ne $dev.arch $imageObj.arch }}{{- fail (printf "Device '%s': '%s'" $deviceId "device and image arch mismatch") }}{{- end }}
 {{- if ne $dev.arch $hookObj.arch }}{{- fail (printf "Device '%s': '%s'" $deviceId "device and hook arch mismatch") }}{{- end }}

--- a/tinkerbell/showcase/templates/devices.yaml
+++ b/tinkerbell/showcase/templates/devices.yaml
@@ -223,7 +223,7 @@ spec:
               BLOCK_DEVICE: {{$rootDiskRootfsPartitionDevice}}
               FS_TYPE: ext4
               IMAGE: {{ $.Values.actions.repository }}/kexec:{{ $.Values.actions.version }}
-              WAIT_SECONDS: 1
+              WAIT_SECONDS: 0
             volumes:
               - /var/run/docker.sock:/var/run/docker.sock
           {{- end }}
@@ -236,7 +236,7 @@ spec:
             command: ["reboot"]
             environment:
               IMAGE: alpine
-              WAIT_SECONDS: 1
+              WAIT_SECONDS: 0
             volumes:
               - /var/run/docker.sock:/var/run/docker.sock
           {{- end }}

--- a/tinkerbell/showcase/templates/hooks.yaml
+++ b/tinkerbell/showcase/templates/hooks.yaml
@@ -35,9 +35,18 @@ data:
     # This script is designed to download the Hook artifacts.
     set -euxo pipefail
     if [[ -f "/output/download_hook_{{$hookId}}_{{$hash}}.done" ]]; then
-      echo "Hook already downloaded ({{$hookId}} - hash: {{$hash}}), skipping."
-      exit 0
+    	echo "Hook already downloaded ({{$hookId}} - hash: {{$hash}}), skipping."
+    	exit 0
     fi
+
+    {{
+    if $hook.skipDownload 
+    }}
+    echo "Skipping download for hook {{$hookId}}."
+    ls -lah "/output/{{$hook.kernel}}"
+    ls -lah "/output/{{$hook.initrd}}"
+    touch "/output/download_hook_{{$hookId}}_{{$hash}}.done"
+    {{ else }}
     mkdir -p "/output/download_hook_{{$hookId}}"
     cd "/output/download_hook_{{$hookId}}"
     declare down_url="{{ $hook.hookDownloadBaseURL }}{{$hook.downloadFile}}"
@@ -51,8 +60,8 @@ data:
     rm -rf "/output/download_hook_{{$hookId}}"
     ls -lah "/output/{{$hook.kernel}}"
     ls -lah "/output/{{$hook.initrd}}"
-    touch "/output/download_hook_{{$hookId}}_{{$hash}}.done"
-    
+    touch "/output/download_hook_{{$hookId}}_{{$hash}}.done"    {{ end }}
+
 ---
 apiVersion: batch/v1
 kind: Job

--- a/tinkerbell/showcase/templates/hooks.yaml
+++ b/tinkerbell/showcase/templates/hooks.yaml
@@ -1,0 +1,94 @@
+{{- range $hookId, $hook := .Values.provision.hook }}
+{{- $common := $.Values.provision.common -}}
+{{- $hook = merge $hook $common }}
+---
+# --> HookId: {{$hookId}}
+  # downloadId: {{ $hook.hookDownloadId }}
+  # downloadFile: {{ $hook.downloadFile }}
+  # hookDownloadBaseUrl: {{ $hook.hookDownloadBaseUrl }}
+{{- $hash := trunc 8 (sha1sum (printf "%s-%s-%s" $hook.hookDownloadId $hook.hookDownloadBaseUrl $hook.downloadFile)) }}
+# Loop over $.Values.hardware.devices (a dictionary) and for each value, check if it's hookRef matches this $hookId - if so, enable this hook.
+{{- $enabledByDeviceUsage := false }}
+{{- range $device := $.Values.hardware.devices }}
+# Testing {{$device.hookRef}} against {{$hookId}}...
+{{- if and $device.enabled (eq $device.hookRef $hookId) -}}
+  # YES!
+{{- $enabledByDeviceUsage = true -}}
+{{- else -}}
+  # NO!
+{{- end -}}
+{{- end }}
+
+{{- if or $enabledByDeviceUsage $hook.enabled }}
+# Enabled hook: {{$hookId}} - force enabled? {{$hook.enabled}} -- enabled by device usage? {{$enabledByDeviceUsage}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "download-hook-{{$hookId}}-{{$hash}}"
+  namespace: "{{ $.Release.Namespace }}"
+  labels:
+    "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+    "app.kubernetes.io/part-of": "tinkerbell-showcase"
+data:
+  entrypoint.sh: |
+    #!/usr/bin/env bash
+    # This script is designed to download the Hook artifacts.
+    set -euxo pipefail
+    if [[ -f "/output/download_hook_{{$hookId}}_{{$hash}}.done" ]]; then
+      echo "Hook already downloaded ({{$hookId}} - hash: {{$hash}}), skipping."
+      exit 0
+    fi
+    mkdir -p "/output/download_hook_{{$hookId}}"
+    cd "/output/download_hook_{{$hookId}}"
+    declare down_url="{{ $hook.hookDownloadBaseURL }}{{$hook.downloadFile}}"
+    declare down_file="/output/download_hook_{{$hookId}}/{{$hook.downloadFile}}"
+    wget -O "${down_file}.tmp" "${down_url}"
+    mv -v "${down_file}.tmp" "${down_file}"
+    mkdir -p "/output/download_hook_{{$hookId}}/extract"
+    cd "/output/download_hook_{{$hookId}}/extract"
+    tar -xvzf "${down_file}"
+    mv -v "/output/download_hook_{{$hookId}}/extract/"* /output/
+    rm -rf "/output/download_hook_{{$hookId}}"
+    ls -lah "/output/{{$hook.kernel}}"
+    ls -lah "/output/{{$hook.initrd}}"
+    touch "/output/download_hook_{{$hookId}}_{{$hash}}.done"
+    
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "download-hook-{{$hookId}}-{{$hash}}"
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+    "app.kubernetes.io/part-of": "tinkerbell-showcase"
+spec:
+  backoffLimit: 50
+  template:
+    metadata:
+      labels:
+        app: download-hook
+    spec:
+      containers:
+        - name: download-hook-{{$hookId}}
+          image: bash:5
+          command: [ "/script/entrypoint.sh" ]
+          volumeMounts:
+            - mountPath: /output
+              name: hook-artifacts
+            - mountPath: /script
+              name: configmap-volume
+      restartPolicy: OnFailure
+      volumes:
+        - name: hook-artifacts
+          hostPath:
+            path: {{ $.Values.tinkerbell.hostDirectory | quote }}
+            type: DirectoryOrCreate
+        - name: configmap-volume
+          configMap:
+            defaultMode: 0700
+            name: "download-hook-{{$hookId}}-{{$hash}}"
+{{- else }}
+# Disabled Hook: {{$hookId}}
+{{- end }}
+{{- end }}

--- a/tinkerbell/showcase/templates/images.yaml
+++ b/tinkerbell/showcase/templates/images.yaml
@@ -85,6 +85,29 @@ data:
     fi
     {{- end }}
 
+    {{- if eq "xz-qcow2-to-img-gz" $image.conversion }}
+    # Download, decompress xz, convert qcow2 to img, compress img to gz.
+    image_url="{{ $image.downloadURL }}"
+    file="/output/{{ $image.image }}"
+    if [[ ! -f "$file" ]]; then
+      echo "Image file $file does not exist. Downloading...."
+      apk add --update pigz pixz qemu-img
+      wget "$image_url" -O "${file}.tmp.xz"
+      echo "Done downloading image. Decompressing xz..."  
+      pixz -d < "${file}.tmp.xz" > "${file}.tmp.unxz"
+      rm -v "${file}.tmp.xz"
+      echo "Done decompressing xz, converting qcow2 to img..."
+      qemu-img convert -O raw "${file}.tmp.unxz" "${file}.tmp.raw"
+      rm -v "${file}.tmp.unxz"
+      echo "Done converting qcow2 to img, compressing img to gz..."
+      pigz < "${file}.tmp.raw" > "${file}"
+      rm -v "${file}.tmp.raw"
+      echo "Done converting image."
+    else
+      echo "Image file $file already exists. Skipping download."
+    fi
+    {{- end }}
+
     {{- if eq "download-only" $image.conversion }}
     # Download only. Image is already in format necessary.
     image_url="{{ $image.downloadURL }}"

--- a/tinkerbell/showcase/templates/images.yaml
+++ b/tinkerbell/showcase/templates/images.yaml
@@ -83,7 +83,35 @@ data:
     else
       echo "Image file $file already exists. Skipping download."
     fi
+    {{- end }}
 
+    {{- if eq "download-only" $image.conversion }}
+    # Download only. Image is already in format necessary.
+    image_url="{{ $image.downloadURL }}"
+    file="/output/{{ $image.image }}"
+    if [[ ! -f "$file" ]]; then
+      echo "Download-only Image file $file does not exist. Downloading...."
+      wget "$image_url" -O "${file}.tmp"
+      echo "Done downloading image. Moving..."
+      mv -v "${file}.tmp" "$file"  
+      echo "Done moving image."
+      rm -f "${file}.tmp.xz"
+    else
+      echo "Download-only image file $file already exists. Skipping download."
+    fi
+    {{- end }}
+
+    {{- if eq "local" $image.conversion }}
+    # Not even download anything. Image should be in there already somehow.
+    image_url="{{ $image.downloadURL }}"
+    file="/output/{{ $image.image }}"
+    if [[ ! -f "$file" ]]; then
+      echo "Image file $file does not exist. Please deploy image file manually, or use a different conversion than none. Sleeping 10s and exiting with error 66."
+      sleep 10
+      exit 66
+    else
+      echo "No-conversion image file $file already exists. Ready to use."
+    fi
     {{- end }}
     
 ---

--- a/tinkerbell/showcase/templates/images.yaml
+++ b/tinkerbell/showcase/templates/images.yaml
@@ -1,0 +1,131 @@
+{{- range $imageId, $image := .Values.provision.images }}
+---
+# --> ImageId: {{ $imageId }}
+  # downloadUrl: "{{ $image.downloadURL }}"
+  # image: "{{ $image.image }}"
+  # conversion: "{{ $image.conversion }}"
+{{- $hash :=  trunc 8 (sha1sum (printf "%s-%s-%s" $image.downloadURL $image.image $image.conversion )) }}
+# Loop over $.Values.hardware.devices (a dictionary) and for each value, check if it's imageRef matches this $imageId - if so, enable this image.
+{{- $enabledByDeviceUsage := false }}
+{{- range $device := $.Values.hardware.devices }}
+# Testing {{$device.imageRef}} against {{$imageId}}...
+{{- if and $device.enabled (eq $device.imageRef $imageId) -}}
+# YES!
+{{- $enabledByDeviceUsage = true -}}
+{{- else -}}
+# NO!
+{{- end -}}
+{{- end }}
+{{- if or $enabledByDeviceUsage $image.enabled }}
+# ImageId: {{ $imageId }} - force enabled? {{ $image.enabled }} -- enabled by device usage? {{ $enabledByDeviceUsage }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "download-image-{{$imageId}}-{{$hash}}"
+  labels:
+    "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+    "app.kubernetes.io/part-of": "tinkerbell-showcase"
+data:
+  entrypoint.sh: |-
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    cat > /etc/apk/repositories << EOF; $(echo)
+    https://dl-cdn.alpinelinux.org/alpine/v$(cut -d'.' -f1,2 /etc/alpine-release)/main/
+    https://dl-cdn.alpinelinux.org/alpine/v$(cut -d'.' -f1,2 /etc/alpine-release)/community/
+    https://dl-cdn.alpinelinux.org/alpine/edge/community/
+    EOF
+    {{- if eq "qemu-to-raw-gzip" $image.conversion }}
+    # This script is designed to download a cloud image file (.img) and then convert it to a .raw.gz file.
+    # This is purpose built so non-raw cloud image files can be used with the "image2disk" action.
+    # See https://artifacthub.io/packages/tbaction/tinkerbell-community/image2disk.
+    image_url=$1
+    file=$2/${image_url##*/}
+    file=${file%.*}.raw.gz
+    if [[ ! -f "$file" ]]; then
+        echo "Image file $file does not exist. Downloading...."
+        apk add --update pigz qemu-img
+        wget "$image_url" -O image.img
+        qemu-img convert -O raw image.img image.raw
+        pigz < image.raw > "$file"
+        rm -f image.img image.raw
+    else
+        echo "File $file already exists, skipping download and conversion."
+    fi
+    {{- end }}
+
+    {{- if eq "none" $image.conversion }}
+    # No conversion, just a simple download; image must be in raw format, possibly compressed.
+    image_url="{{ $image.downloadURL }}"
+    file="/output/{{ $image.image }}"
+    if [[ ! -f "$file" ]]; then
+      echo "Image file $file does not exist. Downloading...."
+      wget "$image_url" -O "${file}.tmp"
+      mv -v "${file}.tmp" "$file"
+      echo "Done downloading image."  
+    else
+      echo "Image file $file already exists. Skipping download."
+    fi
+    {{- end }}
+
+    {{- if eq "xz-to-gz" $image.conversion }}
+    # Download, then produce a .gz file from a .xz file, using pigz and pixz, and using a pipe.
+    image_url="{{ $image.downloadURL }}"
+    file="/output/{{ $image.image }}"
+    if [[ ! -f "$file" ]]; then
+      echo "Image file $file does not exist. Downloading...."
+      apk add --update pigz pixz
+      wget "$image_url" -O "${file}.tmp.xz"
+      echo "Done downloading image. Converting from xz to gz..."  
+      pixz -d < "${file}.tmp.xz" | pigz > "${file}.tmp"  
+      mv -v "${file}.tmp" "$file"
+      echo "Done converting image."
+      rm -f "${file}.tmp.xz"
+    else
+      echo "Image file $file already exists. Skipping download."
+    fi
+
+    {{- end }}
+    
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "download-image-{{$imageId}}-{{$hash}}"
+  labels:
+    "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+    "app.kubernetes.io/part-of": "tinkerbell-showcase"
+spec:
+  template:
+    metadata:
+      labels:
+        "app.kubernetes.io/instance": "{{ $.Release.Name }}"
+        "app.kubernetes.io/part-of": "tinkerbell-showcase"
+    spec:
+      containers:
+        - name: download-{{$imageId}}
+          image: bash:5
+          command: [ "/script/entrypoint.sh" ]
+          args:
+            [
+              "{{$image.downloadURL}}",
+              "/output",
+            ]
+          volumeMounts:
+            - mountPath: /output
+              name: image-artifacts
+            - mountPath: /script
+              name: configmap-volume
+      restartPolicy: OnFailure
+      volumes:
+        - name: image-artifacts
+          hostPath:
+            path: {{ $.Values.tinkerbell.hostDirectory }}
+            type: DirectoryOrCreate
+        - name: configmap-volume
+          configMap:
+            defaultMode: 0700
+            name: "download-image-{{$imageId}}-{{$hash}}"
+{{- else }}
+# ImageId: {{ $imageId }} DISABLED - force enabled? {{ $image.enabled }} -- enabled by device usage? {{ $enabledByDeviceUsage }}
+{{- end }}
+{{- end }}

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -40,7 +40,7 @@ provision:
       kernel: "vmlinuz-aarch64"
       initrd: "initramfs-aarch64"
       kernelCommandLine: ""
-      bootMode: kexec # kexec is no-go here, kernel problem? (persists after enabling CONFIG_KEXEC & trying to fix TB action)
+      bootMode: reboot # kexec is no-go here, kernel problem? (persists after enabling CONFIG_KEXEC & trying to fix TB action)
 
     "armbian-uefi-x86-edge":
       enabled: false
@@ -59,7 +59,7 @@ provision:
       kernel: "vmlinuz-armbian-uefi-arm64-edge"
       initrd: "initramfs-armbian-uefi-arm64-edge"
       kernelCommandLine: ""
-      bootMode: kexec # still no go with kexec -- this is a TB action problem for sure, not kernel problem
+      bootMode: reboot # still no go with kexec -- this is a TB action problem for sure, not kernel problem?
     
     "armbian-meson64-edge":
       enabled: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -17,8 +17,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240414-1316/"
-    hookDownloadId: "20240414-1316" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240419-1740/"
+    hookDownloadId: "20240419-1740" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
@@ -33,31 +33,21 @@ provision:
       kernelCommandLine: ""
       bootMode: reboot # @TODO: this needs to be set per-device & per-image as well # kexec
 
+    "latest-lts-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadFile: "hook-latest-lts-x86_64.tar.gz"
+      kernel: "vmlinuz-latest-lts-x86_64"
+      initrd: "initramfs-latest-lts-x86_64"
+      kernelCommandLine: ""
+      bootMode: reboot
+
     "peg-default-amd64":
       enabled: false
       arch: "x86_64"
       downloadFile: "hook-peg-default-amd64.tar.gz"
       kernel: "vmlinuz-peg-default-amd64"
       initrd: "initramfs-peg-default-amd64"
-      kernelCommandLine: ""
-      bootMode: reboot
-
-    "pegk-default-amd64":
-      enabled: false
-      arch: "x86_64"
-      downloadFile: "hook-pegk-default-amd64.tar.gz"
-      kernel: "vmlinuz-pegk-default-amd64"
-      initrd: "initramfs-pegk-default-amd64"
-      kernelCommandLine: ""
-      bootMode: reboot
-
-    "dev-pegk-default-amd64":
-      enabled: false
-      skipDownload: true # Don't download it, it's already there; just enable it
-      arch: "x86_64"
-      downloadFile: "hook-pegk-default-amd64.tar.gz"
-      kernel: "vmlinuz-pegk-default-amd64"
-      initrd: "initramfs-pegk-default-amd64"
       kernelCommandLine: ""
       bootMode: reboot
 
@@ -78,6 +68,15 @@ provision:
       downloadFile: "hook-aarch64.tar.gz"
       kernel: "vmlinuz-aarch64"
       initrd: "initramfs-aarch64"
+      kernelCommandLine: ""
+      bootMode: reboot # kexec is no-go here, kernel problem? (persists after enabling CONFIG_KEXEC & trying to fix TB action)
+
+    "latest-lts-aarch64":
+      enabled: false
+      arch: "aarch64"
+      downloadFile: "hook-latest-lts-aarch64.tar.gz"
+      kernel: "vmlinuz-latest-lts-aarch64"
+      initrd: "initramfs-latest-lts-aarch64"
       kernelCommandLine: ""
       bootMode: reboot # kexec is no-go here, kernel problem? (persists after enabling CONFIG_KEXEC & trying to fix TB action)
 
@@ -219,6 +218,17 @@ provision:
       downloadURL: "not-used-but-must-change-if-image-changes::rocky-8-baremetal-v666-local.img.gz"
       conversion: "local" # should be there already somehow
       image: "rocky-8-baremetal-v666-local.img.gz"
+      doGrowPart: false
+      doUserAndSshSetup: false
+      doFixResolvConf: false
+      rootfsPartitionNumber: "2" # First one is ESP
+    
+    "fatso-el9-local-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadURL: "not-used-but-must-change-if-image-changes::el-9-baremetal-v666-local.img.gz"
+      conversion: "local" # should be there already somehow
+      image: "el-9-baremetal-v666-local.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -127,6 +127,7 @@ provision:
       conversion: "qemu-to-raw-gzip"
       doGrowPart: true
       doUserAndSshSetup: true
+      doFixResolvConf: true
       rootfsPartitionNumber: "1" # @schema type:[integer] # @TODO fix so this mustn't be a string
 
     "ubuntu-jammy-cloud-amd64":
@@ -137,6 +138,7 @@ provision:
       image: "jammy-server-cloudimg-amd64.raw.gz"
       doGrowPart: true
       doUserAndSshSetup: true
+      doFixResolvConf: true
       rootfsPartitionNumber: "1"
     
     "armbian-uefi-arm64-edge-cloud-k8s":
@@ -147,6 +149,7 @@ provision:
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
       rootfsPartitionNumber: "2" #  1 is ESP, 2 rootfs
     
     "armbian-uefi-x86-edge-cloud-k8s":
@@ -157,6 +160,7 @@ provision:
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
       rootfsPartitionNumber: "2" #  1 is ESP, 2 rootfs
     
     
@@ -168,6 +172,7 @@ provision:
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
       rootfsPartitionNumber: "1"
     
     "armbian-rpardini-orangepi3b-edge-uboot":
@@ -178,6 +183,7 @@ provision:
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
       rootfsPartitionNumber: "1"
     
     "armbian-rpardini-rpi4b-current-not-efi":
@@ -188,6 +194,7 @@ provision:
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
       rootfsPartitionNumber: "2" # rpi image has a fat32 boot partition (config.txt and such), and partition 2 is the real ext4 rootfs
     
     "armbian-rpardini-r58x-vendor-uboot": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
@@ -198,6 +205,7 @@ provision:
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
       rootfsPartitionNumber: "1" # first partition, ext4 rootfs 
     
     "armbian-rpardini-r58x-vendor-uefi-cloud": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
@@ -208,6 +216,7 @@ provision:
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
       rootfsPartitionNumber: "2" # first partition is ESP, 2nd is ext4 rootfs 
     
     "rock-5b-edge-trixie-uefi-dtb": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
@@ -218,6 +227,7 @@ provision:
       conversion: "xz-to-gz" # @TODO: "qcow2-xz-to-img-gz" one day for completeness
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
       rootfsPartitionNumber: "2" # first partition is ESP, 2nd is ext4 rootfs 
     
     "armbian-bookworm-meson64-current-cloud":

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -328,6 +328,7 @@ hardware:
       gateway: "192.168.99.1" # Must be set, otherwise no internet access; can be overriden per-device
       netmask: "255.255.255.0"
       dns: [ "192.168.66.1" ]
+      time_servers: [ "192.168.66.1" ]
 
   devices: # One entry for each machine
     

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -185,9 +185,9 @@ provision:
     "fatso-ubuntu-noble-baremetal-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal-cloud-k8s-nvidia/ubuntu-noble-baremetal-cloud-k8s-nvidia-v1003.img.gz"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal-cloud-k8s-nvidia/ubuntu-noble-baremetal-cloud-k8s-nvidia-v1004.img.gz"
       conversion: "download-only"
-      image: "ubuntu-noble-baremetal-cloud-k8s-nvidia-v1003.img.gz"
+      image: "ubuntu-noble-baremetal-cloud-k8s-nvidia-v1004.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -138,7 +138,7 @@ provision:
       doGrowPart: true
       doUserAndSshSetup: true
       rootfsPartitionNumber: "1"
-      
+    
     "armbian-uefi-arm64-edge-cloud-k8s":
       enabled: false
       arch: "aarch64"
@@ -148,7 +148,7 @@ provision:
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
       rootfsPartitionNumber: "2" #  1 is ESP, 2 rootfs
-      
+    
     "armbian-uefi-x86-edge-cloud-k8s":
       enabled: false
       arch: "aarch64"
@@ -158,7 +158,7 @@ provision:
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
       rootfsPartitionNumber: "2" #  1 is ESP, 2 rootfs
-      
+    
     
     "armbian-rpardini-rockpro64-edge-uboot":
       enabled: false
@@ -206,6 +206,16 @@ provision:
       downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.31-armsurvivors-68/Armbian-unofficial_24.03.31-armsurvivors-68_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.xz"
       image: "Armbian-unofficial_24.03.31-armsurvivors-68_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.gz"
       conversion: "xz-to-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      rootfsPartitionNumber: "2" # first partition is ESP, 2nd is ext4 rootfs 
+    
+    "rock-5b-edge-trixie-uefi-dtb": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.04.05-armsurvivors-87/Armbian-unofficial_24.04.05-armsurvivors-87_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.xz"
+      image: "Armbian-unofficial_24.04.05-armsurvivors-87_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.gz"
+      conversion: "xz-to-gz" # @TODO: "qcow2-xz-to-img-gz" one day for completeness
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
       rootfsPartitionNumber: "2" # first partition is ESP, 2nd is ext4 rootfs 

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -31,7 +31,7 @@ provision:
       kernel: "vmlinuz-x86_64"
       initrd: "initramfs-x86_64"
       kernelCommandLine: ""
-      bootMode: kexec
+      bootMode: reboot # @TODO: this needs to be set per-device & per-image as well # kexec
 
     "default-hook-aarch64":
       enabled: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -210,7 +210,7 @@ hardware:
       rootDisk: "/dev/sda"
       ipv4:
         address: "192.168.66.245"
-      hookRef: "armbian-uefi-x86-edge" # "default-hook-amd64" # defined above
+      hookRef: "armbian-uefi-x86-edge" # not really used in this case; Hook dev environment controls the kernel there
       imageRef: "ubuntu-jammy-cloud-amd64" # defined above
       extraKernelCommandLine: "console=ttyS0"
 
@@ -232,14 +232,25 @@ hardware:
     # Examples for virtual machines, ran outside of Hook's build system.
     # Most virtualization software has support for PXE booting.
     # You will need to have (bridging/etc) setup to get a proper IP address from a real Smee, etc.
-    "vm03":
+    "vm03": # For Armbian kernel Hook, and Ubuntu cloud image
       enabled: false
       arch: aarch64
       mac: "52:54:00:01:03:03"
       rootDisk: "/dev/vdb"
       ipv4:
         address: "192.168.99.41"
-      hookRef: "armbian-uefi-arm64-edge" # "default-hook-aarch64" # defined above
+      hookRef: "armbian-uefi-arm64-edge"
+      imageRef: "ubuntu-jammy-cloud-arm64"
+      extraKernelCommandLine: "console=ttyAMA0"
+    
+    "vm04": # For default arm64 kernel Hook, and Ubuntu cloud image
+      enabled: false
+      arch: aarch64
+      mac: "52:54:00:01:03:04"
+      rootDisk: "/dev/vdb"
+      ipv4:
+        address: "192.168.99.41"
+      hookRef: "default-hook-aarch64"
       imageRef: "ubuntu-jammy-cloud-arm64" # defined above
       extraKernelCommandLine: "console=ttyAMA0"
 

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -18,8 +18,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240604-0609/"
-    hookDownloadId: "20240604-0609" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240608-2139/"
+    hookDownloadId: "20240608-2139" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
@@ -267,6 +267,18 @@ provision:
       arch: "aarch64"
       downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Odroidhc4_bookworm_edge_6.8.10-metadata-cloud.img.qcow2.xz"
       image: "Armbian-unofficial_24.05.22-armsurvivors-189_Odroidhc4_bookworm_edge_6.8.10-metadata-cloud.img.gz"
+      conversion: "xz-qcow2-to-img-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
+      doInjectHegelCloudInit: true
+      rootfsPartitionNumber: "1" # rootfs is the one and only
+    
+    "armbian-rpardini-nanopct6-cloud-uboot":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.06.07-armsurvivors-215/Armbian-unofficial_24.06.07-armsurvivors-215_Nanopct6_bookworm_edge_6.10.0-rc2-metadata-cloud.img.qcow2.xz"
+      image: "Armbian-unofficial_24.06.07-armsurvivors-215_Nanopct6_bookworm_edge_6.10.0-rc2-metadata-cloud.img.gz"
       conversion: "xz-qcow2-to-img-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -525,3 +537,25 @@ hardware:
       hookRef: "armbian-rk35xx-vendor"
       imageRef: "armbian-rpardini-r58x-vendor-uefi-cloud" # "armbian-rpardini-r58x-vendor-uboot"
       extraKernelCommandLine: "console=tty1 console=ttyFIQ0,1500000 " #    # Last console defined "wins", thus use tty1 last if no serial console
+
+    "nanopct6lan1":
+      enabled: false
+      arch: aarch64
+      mac: "8e:b4:90:97:32:30"
+      rootDisk: "/dev/nvme0NOENOENOENEyet"
+      ipv4:
+        address: "192.168.99.171"
+      hookRef: "armbian-rk3588-edge"
+      imageRef: "armbian-rpardini-nanopct6-cloud-uboot" # "armbian-rpardini-r58x-vendor-uboot"
+      extraKernelCommandLine: "console=ttyS2,1500000 " #    # Last console defined "wins", thus use tty1 last if no serial console
+
+    "nanopct6lan2":
+      enabled: false
+      arch: aarch64
+      mac: "8e:b4:90:97:32:31"
+      rootDisk: "/dev/nvme0NOENOENOENEyet"
+      ipv4:
+        address: "192.168.99.172"
+      hookRef: "armbian-rk3588-edge"
+      imageRef: "armbian-rpardini-nanopct6-cloud-uboot" # "armbian-rpardini-r58x-vendor-uboot"
+      extraKernelCommandLine: "console=ttyS2,1500000 " #    # Last console defined "wins", thus use tty1 last if no serial console

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -17,8 +17,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240413-0904/"
-    hookDownloadId: "20240413-0904" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240414-1316/"
+    hookDownloadId: "20240414-1316" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
@@ -205,9 +205,9 @@ provision:
     "fatso-ubuntu-noble-local-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "not-used-but-must-change-if-image-changes::ubuntu-noble-baremetal-v1000-local.img.gz"
+      downloadURL: "not-used-but-must-change-if-image-changes::ubuntu-noble-baremetal-v666-local.img.gz"
       conversion: "local" # should be there already somehow
-      image: "ubuntu-noble-baremetal-v1000-local.img.gz"
+      image: "ubuntu-noble-baremetal-v666-local.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -144,9 +144,20 @@ provision:
     "fatso-ubuntu-noble-baremetal-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal/ubuntu-noble-baremetal-v1000.img.gz"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal/ubuntu-noble-baremetal-v1001.img.gz"
       conversion: "download-only"
-      image: "ubuntu-noble-baremetal-v1000.img.gz"
+      image: "ubuntu-noble-baremetal-v1001.img.gz"
+      doGrowPart: false
+      doUserAndSshSetup: false
+      doFixResolvConf: false
+      rootfsPartitionNumber: "2" # First one is ESP
+    
+    "fatso-rocky8-baremetal-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/rocky-8-baremetal/rocky-8-baremetal-v1001.img.gz"
+      conversion: "download-only"
+      image: "rocky-8-baremetal-v1001.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false
@@ -155,9 +166,20 @@ provision:
     "fatso-ubuntu-noble-local-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "not-used-but-must-change-if-image-changes"
+      downloadURL: "not-used-but-must-change-if-image-changes::ubuntu-noble-baremetal-v1000-local.img.gz"
       conversion: "local" # should be there already somehow
       image: "ubuntu-noble-baremetal-v1000-local.img.gz"
+      doGrowPart: false
+      doUserAndSshSetup: false
+      doFixResolvConf: false
+      rootfsPartitionNumber: "2" # First one is ESP
+    
+    "fatso-rocky8-local-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadURL: "not-used-but-must-change-if-image-changes::rocky-8-baremetal-v666-local.img.gz"
+      conversion: "local" # should be there already somehow
+      image: "rocky-8-baremetal-v666-local.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -1,0 +1,311 @@
+# Basic information on how Tinkerbell is setup.
+tinkerbell:
+  hostDirectory: "/opt/hook" # hostPath where Hook & images are downloaded & served from
+  hookURL: "http://192.168.66.71:8080" # # URL where Hook is served from
+  imagesURL: "http://192.168.66.71:8080" # # URL where images are served from
+  syslogHost: "192.168.66.71" # Syslog host, usually smee
+  grpcAuthority: "192.168.66.71:42113" # Tink's gRPC authority
+
+actions:
+  repository: "quay.io/tinkerbellrpardini/actions" # rpardini's fork with some fixes for arm64
+  version: "latest"
+
+# Generates download jobs and configs for easy show-off'ing of Tinkerbell on diverse hardware
+provision:
+  # @TODO: many simultaneous download jobs can drive an SD-card/low-bandwidth cluster to its knees. Consider a single download job for all
+  
+  common:
+    # Used together with downloadFile field in each hook;
+    # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240331-0055/"
+    hookDownloadId: "20240331-0055" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+  
+  # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
+  # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
+  # to download/prepare it even if no device is using it.
+  hook:
+    "default-hook-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadFile: "hook-x86_64.tar.gz"
+      kernel: "vmlinuz-x86_64"
+      initrd: "initramfs-x86_64"
+      kernelCommandLine: ""
+      bootMode: kexec
+
+    "default-hook-aarch64":
+      enabled: false
+      arch: "aarch64"
+      downloadFile: "hook-aarch64.tar.gz"
+      kernel: "vmlinuz-aarch64"
+      initrd: "initramfs-aarch64"
+      kernelCommandLine: ""
+      bootMode: kexec # kexec is no-go here, kernel problem? (persists after enabling CONFIG_KEXEC & trying to fix TB action)
+
+    "armbian-uefi-x86-edge":
+      enabled: false
+      arch: "x86_64"
+      downloadFile: "hook-armbian-uefi-x86-edge.tar.gz"
+      kernel: "vmlinuz-armbian-uefi-x86-edge"
+      initrd: "initramfs-armbian-uefi-x86-edge"
+      kernelCommandLine: "intel_iommu=on iommu=pt"
+      bootMode: kexec
+    
+    
+    "armbian-uefi-arm64-edge":
+      enabled: false
+      arch: "aarch64"
+      downloadFile: "hook-armbian-uefi-arm64-edge.tar.gz"
+      kernel: "vmlinuz-armbian-uefi-arm64-edge"
+      initrd: "initramfs-armbian-uefi-arm64-edge"
+      kernelCommandLine: ""
+      bootMode: kexec # still no go with kexec -- this is a TB action problem for sure, not kernel problem
+    
+    "armbian-meson64-edge":
+      enabled: false
+      arch: "aarch64"
+      downloadFile: "hook-armbian-meson64-edge.tar.gz"
+      kernel: "vmlinuz-armbian-meson64-edge"
+      initrd: "initramfs-armbian-meson64-edge"
+      kernelCommandLine: "acpi=off efi=noruntime"
+      bootMode: reboot
+    
+    "armbian-rockchip64-edge":
+      enabled: false
+      arch: "aarch64"
+      downloadFile: "hook-armbian-rockchip64-edge.tar.gz"
+      kernel: "vmlinuz-armbian-rockchip64-edge"
+      initrd: "initramfs-armbian-rockchip64-edge"
+      kernelCommandLine: ""
+      bootMode: reboot
+    
+    "armbian-bcm2711-current":
+      enabled: false
+      arch: "aarch64"
+      downloadFile: "hook-armbian-bcm2711-current.tar.gz"
+      kernel: "vmlinuz-armbian-bcm2711-current"
+      initrd: "initramfs-armbian-bcm2711-current"
+      kernelCommandLine: ""
+      bootMode: reboot
+    
+    "armbian-rk35xx-vendor":
+      enabled: false
+      arch: "aarch64"
+      downloadFile: "hook-armbian-rk35xx-vendor.tar.gz"
+      kernel: "vmlinuz-armbian-rk35xx-vendor"
+      initrd: "initramfs-armbian-rk35xx-vendor"
+      kernelCommandLine: "acpi=off efi=noruntime splash=verbose"
+      bootMode: reboot
+    
+    "armbian-rk35xx-legacy":
+      enabled: false
+      arch: "aarch64"
+      downloadFile: "hook-armbian-rk35xx-legacy.tar.gz"
+      kernel: "vmlinuz-armbian-rk35xx-legacy"
+      initrd: "initramfs-armbian-rk35xx-legacy"
+      kernelCommandLine: "" # acpi=off efi=noruntime splash=verbose
+      bootMode: reboot
+  
+  # Define deployment images; we've a few examples using Ubuntu and Armbian
+  # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
+  # to download/prepare it even if no device is using it.
+  images:
+    "ubuntu-jammy-cloud-arm64":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://cloud-images.ubuntu.com/daily/server/jammy/current/jammy-server-cloudimg-arm64.img"
+      image: "jammy-server-cloudimg-arm64.raw.gz"
+      conversion: "qemu-to-raw-gzip"
+      doGrowPart: true
+      doUserAndSshSetup: true
+      rootfsPartitionNumber: "1" # @schema type:[integer] # @TODO fix so this mustn't be a string
+
+    "ubuntu-jammy-cloud-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadURL: "https://cloud-images.ubuntu.com/daily/server/jammy/current/jammy-server-cloudimg-amd64.img"
+      conversion: "qemu-to-raw-gzip"
+      image: "jammy-server-cloudimg-amd64.raw.gz"
+      doGrowPart: true
+      doUserAndSshSetup: true
+      rootfsPartitionNumber: "1"
+    
+    "armbian-rpardini-rockpro64-edge-uboot":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.30-armsurvivors-64/Armbian-unofficial_24.03.30-armsurvivors-64_Rockpro64_bookworm_edge_6.8.2.img.xz"
+      image: "Armbian-unofficial_24.03.30-armsurvivors-64_Rockpro64_bookworm_edge_6.8.2.img.gz"
+      conversion: "xz-to-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      rootfsPartitionNumber: "1"
+    
+    "armbian-rpardini-orangepi3b-edge-uboot":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.30-armsurvivors-64/Armbian-unofficial_24.03.30-armsurvivors-64_Orangepi3b_bookworm_edge_6.8.2.img.xz"
+      image: "Armbian-unofficial_24.03.30-armsurvivors-64_Orangepi3b_bookworm_edge_6.8.2.img.gz"
+      conversion: "xz-to-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      rootfsPartitionNumber: "1"
+    
+    "armbian-rpardini-rpi4b-current-not-efi":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.30-armsurvivors-64/Armbian-unofficial_24.03.30-armsurvivors-64_Rpi4b_bookworm_current_6.6.23.img.xz"
+      image: "Armbian-unofficial_24.03.30-armsurvivors-64_Rpi4b_bookworm_current_6.6.23.img.gz"
+      conversion: "xz-to-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      rootfsPartitionNumber: "2" # rpi image has a fat32 boot partition (config.txt and such), and partition 2 is the real ext4 rootfs
+    
+    "armbian-rpardini-r58x-vendor-uboot": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.30-armsurvivors-64/Armbian-unofficial_24.03.30-armsurvivors-64_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.xz"
+      image: "Armbian-unofficial_24.03.30-armsurvivors-64_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.gz"
+      conversion: "xz-to-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      rootfsPartitionNumber: "1" # first partition, ext4 rootfs 
+    
+    "armbian-bookworm-meson64-current-cloud":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://..../"
+      image: "armbian-bookworm-meson64.img"
+      rootfsPartitionNumber: "1"
+
+# Generates CRs triplets with Hardware, Workflow, and Template, using by-id references to the hook and images above.
+
+hardware:
+  common:
+    uefi: true
+    ipv4:
+      gateway: "192.168.99.1" # Must be set, otherwise no internet access; can be overriden per-device
+      netmask: "255.255.255.0"
+      dns: [ "192.168.66.1" ]
+
+  devices: # One entry for each machine
+    
+    # Examples for use in Hook development environment.
+    # There is a `bash build.sh build-run-qemu` command in Hook, that paired with
+    # `export MAC=11:22:33:44:55:66 TINK_SERVER=x.y.z.y` can be used with the below "machines".
+    # The MAC address is not really used by the qemu VM, but is passed via kernel cmdline.
+    "run-qemu-x86":
+      enabled: false
+      arch: x86_64
+      mac: "11:22:33:44:55:66"
+      rootDisk: "/dev/sda"
+      ipv4:
+        address: "192.168.66.245"
+      hookRef: "armbian-uefi-x86-edge" # "default-hook-amd64" # defined above
+      imageRef: "ubuntu-jammy-cloud-amd64" # defined above
+      extraKernelCommandLine: "console=ttyS0"
+
+    "run-qemu-arm64":
+      enabled: false
+      arch: aarch64
+      mac: "11:22:33:44:55:77"
+      rootDisk: "/dev/vda" # wonder why linuxkit only uses virtio for arm64? intel is sda...
+      ipv4:
+        address: "192.168.66.246"
+      hookRef: "armbian-uefi-arm64-edge" # "default-hook-aarch64" # defined above
+      imageRef: "ubuntu-jammy-cloud-arm64" # defined above
+      extraKernelCommandLine: "console=ttyAMA0"
+    
+    
+    ###
+    ###
+    ###
+    # Examples for virtual machines, ran outside of Hook's build system.
+    # Most virtualization software has support for PXE booting.
+    # You will need to have (bridging/etc) setup to get a proper IP address from a real Smee, etc.
+    "vm03":
+      enabled: false
+      arch: aarch64
+      mac: "52:54:00:01:03:03"
+      rootDisk: "/dev/vdb"
+      ipv4:
+        address: "192.168.99.41"
+      hookRef: "armbian-uefi-arm64-edge" # "default-hook-aarch64" # defined above
+      imageRef: "ubuntu-jammy-cloud-arm64" # defined above
+      extraKernelCommandLine: "console=ttyAMA0"
+
+    "vm09":
+      enabled: false
+      arch: x86_64
+      mac: "52:54:00:01:03:09"
+      rootDisk: "/dev/vdb"
+      ipv4:
+        address: "192.168.99.42"
+      hookRef: "armbian-uefi-x86-edge" # "default-hook-amd64" # defined above
+      imageRef: "ubuntu-jammy-cloud-amd64" # defined above
+      extraKernelCommandLine: "console=ttyS0"
+    
+    
+    ###
+    ###
+    ###
+    # Examples for actual bare-metal hardware, mostly arm64 SBCs.
+    
+    
+    # Khadas VIM3L and other meson64-based boards (u-boot)
+    "vim3l":
+      enabled: false
+      arch: aarch64
+      mac: "c8:63:14:71:2a:6d"
+      rootDisk: "/dev/mmcblk0"
+      ipv4:
+        address: "192.168.99.51"
+      hookRef: "armbian-meson64-edge"
+      imageRef: "ubuntu-jammy-cloud-arm64"
+      extraKernelCommandLine: "console=ttyAML0,115200"
+    
+    # RockPro64 and other rockchip64-based boards (u-boot)
+    "rockpro64":
+      enabled: false
+      arch: aarch64
+      mac: "2a:36:cb:a2:ae:b8"
+      #rootDisk: "/dev/mmcblk2"  # mmcblk2 is the eMMC, mmcblk1 is the SD card
+      rootDisk: "/dev/disk/by-id/mmc-AJTD4R_0x0b05e84d" # much safer to use this style
+      ipv4:
+        address: "192.168.99.52"
+      hookRef: "armbian-rockchip64-edge" # defined above
+      imageRef: "armbian-rpardini-rockpro64-edge-uboot" # defined above
+      extraKernelCommandLine: "console=ttyS2,1500000"
+    
+    "orangepi3b":
+      enabled: false
+      arch: aarch64
+      mac: "b6:a7:96:d5:f1:84"
+      rootDisk: "/dev/disk/by-id/mmc-A3A551_0x2f8c5bd0" # /dev/mmcblk0 is the eMMC
+      ipv4:
+        address: "192.168.99.53"
+      hookRef: "armbian-rockchip64-edge"
+      imageRef: "armbian-rpardini-orangepi3b-edge-uboot" # defined above
+      extraKernelCommandLine: "console=ttyS2,1500000"
+    
+    # Raspberry Pi 4B (bcm2711), using edk2 UEFI firmware on an SD card, and an external NVMe-USB disk
+    "rpi4b":
+      enabled: false
+      arch: aarch64
+      mac: "dc:a6:32:ec:8b:49"
+      rootDisk: "/dev/disk/by-id/wwn-0x3001237923792379"
+      ipv4:
+        address: "192.168.99.54"
+      hookRef: "armbian-bcm2711-current" # works, as long as UEFI is set with ACPI+DTB and no 3gb limit. Use edk2 from https://github.com/pftf/RPi4
+      imageRef: "armbian-rpardini-rpi4b-current-not-efi" # defined above
+      extraKernelCommandLine: "console=tty1 console=ttyAMA0,115200 loglevel=7" # Last console defined "wins", thus use tty1 last if no serial console
+
+    "mekotronics-r58x-pro-via-usb":
+      enabled: false
+      arch: aarch64
+      mac: "3c:18:a0:15:9a:9f" # 3C18A0159A9F
+      ipv4:
+        address: "192.168.99.55"
+      hookRef: "armbian-rk35xx-legacy" # "armbian-rk35xx-vendor"
+      imageRef: "armbian-rpardini-r58x-vendor-uboot"
+      extraKernelCommandLine: "console=ttyFIQ0:1500000 " # console=tty1  # Last console defined "wins", thus use tty1 last if no serial console
+      rootDisk: "/dev/nvme0NOENOENOENEyet"

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -432,6 +432,17 @@ hardware:
       imageRef: "ubuntu-jammy-cloud-arm64"
       extraKernelCommandLine: "console=ttyAML0,115200"
     
+    "t95z":
+      enabled: false
+      arch: aarch64
+      mac: "c8:63:14:71:2a:6d"
+      rootDisk: "/dev/NOT_YET"
+      ipv4:
+        address: "192.168.99.27"
+      hookRef: "armbian-meson64-edge"
+      imageRef: "ubuntu-jammy-cloud-arm64" # @TODO wrong
+      extraKernelCommandLine: "console=ttyAML0,115200"
+    
     # RockPro64 and other rockchip64-based boards (u-boot)
     "rockpro64":
       enabled: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -18,8 +18,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240519-1405/"
-    hookDownloadId: "20240519-1405" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240519-1935/"
+    hookDownloadId: "20240519-1935" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -18,8 +18,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240522-1109/"
-    hookDownloadId: "20240522-1109" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240603-0515/"
+    hookDownloadId: "20240603-0515" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
@@ -185,9 +185,9 @@ provision:
     "fatso-ubuntu-noble-baremetal-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal-cloud-k8s-nvidia/ubuntu-noble-baremetal-cloud-k8s-nvidia-v1005.img.gz"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal-cloud-k8s-nvidia/ubuntu-noble-baremetal-cloud-k8s-nvidia-v1008.img.gz"
       conversion: "download-only"
-      image: "ubuntu-noble-baremetal-cloud-k8s-nvidia-v1005.img.gz"
+      image: "ubuntu-noble-baremetal-cloud-k8s-nvidia-v1008.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false
@@ -197,9 +197,9 @@ provision:
     "fatso-el9-baremetal-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/el-9-baremetal/el-9-baremetal-v1003.img.gz"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/el-9-baremetal/el-9-baremetal-v1008.img.gz"
       conversion: "download-only"
-      image: "el-9-baremetal-v1003.img.gz"
+      image: "el-9-baremetal-v1008.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -185,55 +185,21 @@ provision:
     "fatso-ubuntu-noble-baremetal-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal/ubuntu-noble-baremetal-v1002.img.gz"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal-cloud-k8s-nvidia/ubuntu-noble-baremetal-cloud-k8s-nvidia-v1003.img.gz"
       conversion: "download-only"
-      image: "ubuntu-noble-baremetal-v1002.img.gz"
+      image: "ubuntu-noble-baremetal-cloud-k8s-nvidia-v1003.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false
       doInjectHegelCloudInit: true
       rootfsPartitionNumber: "2" # First one is ESP
     
-    "fatso-rocky8-baremetal-amd64":
+    "fatso-el9-baremetal-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/rocky-8-baremetal/rocky-8-baremetal-v1002.img.gz"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/el-9-baremetal/el-9-baremetal-v1003.img.gz"
       conversion: "download-only"
-      image: "rocky-8-baremetal-v1002.img.gz"
-      doGrowPart: false
-      doUserAndSshSetup: false
-      doFixResolvConf: false
-      rootfsPartitionNumber: "2" # First one is ESP
-    
-    "fatso-ubuntu-noble-local-amd64":
-      enabled: false
-      arch: "x86_64"
-      downloadURL: "not-used-but-must-change-if-image-changes::ubuntu-noble-baremetal-v666-local.img.gz"
-      conversion: "local" # should be there already somehow
-      image: "ubuntu-noble-baremetal-v666-local.img.gz"
-      doGrowPart: false
-      doUserAndSshSetup: false
-      doFixResolvConf: false
-      doInjectHegelCloudInit: true
-      rootfsPartitionNumber: "2" # First one is ESP
-    
-    "fatso-rocky8-local-amd64":
-      enabled: false
-      arch: "x86_64"
-      downloadURL: "not-used-but-must-change-if-image-changes::rocky-8-baremetal-v666-local.img.gz"
-      conversion: "local" # should be there already somehow
-      image: "rocky-8-baremetal-v666-local.img.gz"
-      doGrowPart: false
-      doUserAndSshSetup: false
-      doFixResolvConf: false
-      rootfsPartitionNumber: "2" # First one is ESP
-    
-    "fatso-el9-local-amd64":
-      enabled: false
-      arch: "x86_64"
-      downloadURL: "not-used-but-must-change-if-image-changes::el-9-baremetal-v666-local.img.gz"
-      conversion: "local" # should be there already somehow
-      image: "el-9-baremetal-v666-local.img.gz"
+      image: "el-9-baremetal-v1003.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false
@@ -328,12 +294,30 @@ provision:
       doFixResolvConf: true
       rootfsPartitionNumber: "2" # first partition is ESP, 2nd is ext4 rootfs 
     
-    "armbian-bookworm-meson64-current-cloud":
+    # local development versions of fatso images; identical 
+    "fatso-ubuntu-noble-local-amd64":
       enabled: false
-      arch: "aarch64"
-      downloadURL: "https://..../"
-      image: "armbian-bookworm-meson64.img"
-      rootfsPartitionNumber: "1"
+      arch: "x86_64"
+      downloadURL: "not-used-but-must-change-if-image-changes::ubuntu-noble-baremetal-cloud-k8s-nvidia-v666-local.img.gz"
+      conversion: "local" # should be there already somehow
+      image: "ubuntu-noble-baremetal-cloud-k8s-nvidia-v666-local.img.gz"
+      doGrowPart: false
+      doUserAndSshSetup: false
+      doFixResolvConf: false
+      doInjectHegelCloudInit: true
+      rootfsPartitionNumber: "2" # First one is ESP
+    
+    "fatso-el9-local-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadURL: "not-used-but-must-change-if-image-changes::el-9-baremetal-v666-local.img.gz"
+      conversion: "local" # should be there already somehow
+      image: "el-9-baremetal-v666-local.img.gz"
+      doGrowPart: false
+      doUserAndSshSetup: false
+      doFixResolvConf: false
+      rootfsPartitionNumber: "2" # First one is ESP
+
 
 # Generates CRs triplets with Hardware, Workflow, and Template, using by-id references to the hook and images above.
 

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -208,9 +208,9 @@ provision:
     "armbian-uefi-arm64-edge-cloud-k8s":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.04.04-armsurvivors-86/Armbian-unofficial_24.04.04-armsurvivors-86_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
-      image: "Armbian-unofficial_24.04.04-armsurvivors-86_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.gz"
-      conversion: "xz-to-gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
+      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.gz"
+      conversion: "xz-qcow2-to-img-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
       doFixResolvConf: true
@@ -219,9 +219,9 @@ provision:
     "armbian-uefi-x86-edge-cloud-k8s":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.04.04-armsurvivors-86/Armbian-unofficial_24.04.04-armsurvivors-86_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
-      image: "Armbian-unofficial_24.04.04-armsurvivors-86_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.gz"
-      conversion: "xz-to-gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
+      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.gz"
+      conversion: "xz-qcow2-to-img-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
       doFixResolvConf: true
@@ -231,8 +231,8 @@ provision:
     "armbian-rpardini-rockpro64-edge-uboot":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.30-armsurvivors-64/Armbian-unofficial_24.03.30-armsurvivors-64_Rockpro64_bookworm_edge_6.8.2.img.xz"
-      image: "Armbian-unofficial_24.03.30-armsurvivors-64_Rockpro64_bookworm_edge_6.8.2.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Rockpro64_bookworm_edge_6.8.2.img.xz"
+      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Rockpro64_bookworm_edge_6.8.2.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -242,19 +242,31 @@ provision:
     "armbian-rpardini-orangepi3b-edge-uboot":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.12-armsurvivors-166/Armbian-unofficial_24.05.12-armsurvivors-166_Orangepi3b_bookworm_edge_6.8.9.img.xz"
-      image: "Armbian-unofficial_24.05.12-armsurvivors-166_Orangepi3b_bookworm_edge_6.8.9.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Orangepi3b_bookworm_edge_6.8.9.img.xz"
+      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Orangepi3b_bookworm_edge_6.8.9.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
       doFixResolvConf: true
       rootfsPartitionNumber: "1"
     
+    "armbian-rpardini-t95z-cloud-edge-uboot":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_T95z_bookworm_edge_6.8.10-metadata-cloud.img.qcow2.xz"
+      image: "Armbian-unofficial_24.05.20-armsurvivors-184_T95z_bookworm_edge_6.8.10-metadata-cloud.img.gz"
+      conversion: "xz-qcow2-to-img-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
+      doInjectHegelCloudInit: true
+      rootfsPartitionNumber: "1" # rootfs is the one and only
+    
     "armbian-rpardini-rpi4b-current-not-efi":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.30-armsurvivors-64/Armbian-unofficial_24.03.30-armsurvivors-64_Rpi4b_bookworm_current_6.6.23.img.xz"
-      image: "Armbian-unofficial_24.03.30-armsurvivors-64_Rpi4b_bookworm_current_6.6.23.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Rpi4b_bookworm_current_6.6.23.img.xz"
+      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Rpi4b_bookworm_current_6.6.23.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -264,8 +276,8 @@ provision:
     "armbian-rpardini-r58x-vendor-uboot": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.30-armsurvivors-64/Armbian-unofficial_24.03.30-armsurvivors-64_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.xz"
-      image: "Armbian-unofficial_24.03.30-armsurvivors-64_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.xz"
+      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -275,8 +287,8 @@ provision:
     "armbian-rpardini-r58x-vendor-uefi-cloud": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.31-armsurvivors-68/Armbian-unofficial_24.03.31-armsurvivors-68_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.xz"
-      image: "Armbian-unofficial_24.03.31-armsurvivors-68_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.xz"
+      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -286,8 +298,8 @@ provision:
     "rock-5b-edge-trixie-uefi-dtb": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.04.05-armsurvivors-87/Armbian-unofficial_24.04.05-armsurvivors-87_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.xz"
-      image: "Armbian-unofficial_24.04.05-armsurvivors-87_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.xz"
+      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.gz"
       conversion: "xz-to-gz" # @TODO: "qcow2-xz-to-img-gz" one day for completeness
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -436,11 +448,11 @@ hardware:
       enabled: false
       arch: aarch64
       mac: "c8:63:14:71:2a:6d"
-      rootDisk: "/dev/NOT_YET"
+      rootDisk: "/dev/sda" # USB Disk plugged in
       ipv4:
         address: "192.168.99.27"
       hookRef: "armbian-meson64-edge"
-      imageRef: "ubuntu-jammy-cloud-arm64" # @TODO wrong
+      imageRef: "armbian-rpardini-t95z-cloud-edge-uboot"
       extraKernelCommandLine: "console=ttyAML0,115200"
     
     # RockPro64 and other rockchip64-based boards (u-boot)

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -17,8 +17,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240331-0055/"
-    hookDownloadId: "20240331-0055" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240404-2216/"
+    hookDownloadId: "20240404-2216" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
@@ -94,6 +94,15 @@ provision:
       downloadFile: "hook-armbian-rk35xx-vendor.tar.gz"
       kernel: "vmlinuz-armbian-rk35xx-vendor"
       initrd: "initramfs-armbian-rk35xx-vendor"
+      kernelCommandLine: "" # acpi=off efi=noruntime splash=verbose
+      bootMode: reboot
+    
+    "armbian-rk3588-edge":
+      enabled: false
+      arch: "aarch64"
+      downloadFile: "hook-armbian-rk3588-edge.tar.gz"
+      kernel: "vmlinuz-armbian-rk3588-edge"
+      initrd: "initramfs-armbian-rk3588-edge"
       kernelCommandLine: "" # acpi=off efi=noruntime splash=verbose
       bootMode: reboot
     

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -183,9 +183,9 @@ provision:
     "fatso-ubuntu-noble-baremetal-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal/ubuntu-noble-baremetal-v1001.img.gz"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal/ubuntu-noble-baremetal-v1002.img.gz"
       conversion: "download-only"
-      image: "ubuntu-noble-baremetal-v1001.img.gz"
+      image: "ubuntu-noble-baremetal-v1002.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false
@@ -194,9 +194,9 @@ provision:
     "fatso-rocky8-baremetal-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/rocky-8-baremetal/rocky-8-baremetal-v1001.img.gz"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/rocky-8-baremetal/rocky-8-baremetal-v1002.img.gz"
       conversion: "download-only"
-      image: "rocky-8-baremetal-v1001.img.gz"
+      image: "rocky-8-baremetal-v1002.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -18,8 +18,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240519-1935/"
-    hookDownloadId: "20240519-1935" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240520-0729/"
+    hookDownloadId: "20240520-0729" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -193,6 +193,7 @@ provision:
       doFixResolvConf: false
       doInjectHegelCloudInit: true
       rootfsPartitionNumber: "2" # First one is ESP
+      doAddEFIBootEntry: true
     
     "fatso-el9-baremetal-amd64":
       enabled: false
@@ -204,6 +205,7 @@ provision:
       doUserAndSshSetup: false
       doFixResolvConf: false
       rootfsPartitionNumber: "2" # First one is ESP
+      doAddEFIBootEntry: true
     
     "armbian-uefi-arm64-edge-cloud-k8s":
       enabled: false
@@ -343,6 +345,7 @@ provision:
       doFixResolvConf: false
       doInjectHegelCloudInit: true
       rootfsPartitionNumber: "2" # First one is ESP
+      doAddEFIBootEntry: true
     
     "fatso-el9-local-amd64":
       enabled: false
@@ -354,6 +357,7 @@ provision:
       doUserAndSshSetup: false
       doFixResolvConf: false
       rootfsPartitionNumber: "2" # First one is ESP
+      doAddEFIBootEntry: true
 
 
 # Generates CRs triplets with Hardware, Workflow, and Template, using by-id references to the hook and images above.

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -178,8 +178,8 @@ provision:
     "armbian-rpardini-orangepi3b-edge-uboot":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.30-armsurvivors-64/Armbian-unofficial_24.03.30-armsurvivors-64_Orangepi3b_bookworm_edge_6.8.2.img.xz"
-      image: "Armbian-unofficial_24.03.30-armsurvivors-64_Orangepi3b_bookworm_edge_6.8.2.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.04.06-armsurvivors-90/Armbian-unofficial_24.04.06-armsurvivors-90_Orangepi3b_bookworm_edge_6.8.4.img.xz"
+      image: "Armbian-unofficial_24.04.06-armsurvivors-90_Orangepi3b_bookworm_edge_6.8.4.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -193,7 +193,8 @@ provision:
       doFixResolvConf: false
       doInjectHegelCloudInit: true
       rootfsPartitionNumber: "2" # First one is ESP
-      doAddEFIBootEntry: true
+      #doAddEFIBootEntry: true
+      doRestoreGRUBNormalcy: true
     
     "fatso-el9-baremetal-amd64":
       enabled: false
@@ -205,7 +206,8 @@ provision:
       doUserAndSshSetup: false
       doFixResolvConf: false
       rootfsPartitionNumber: "2" # First one is ESP
-      doAddEFIBootEntry: true
+      #doAddEFIBootEntry: true
+      doRestoreGRUBNormalcy: true
     
     "armbian-uefi-arm64-edge-cloud-k8s":
       enabled: false
@@ -345,7 +347,8 @@ provision:
       doFixResolvConf: false
       doInjectHegelCloudInit: true
       rootfsPartitionNumber: "2" # First one is ESP
-      doAddEFIBootEntry: true
+      #doAddEFIBootEntry: true
+      doRestoreGRUBNormalcy: true
     
     "fatso-el9-local-amd64":
       enabled: false
@@ -357,7 +360,8 @@ provision:
       doUserAndSshSetup: false
       doFixResolvConf: false
       rootfsPartitionNumber: "2" # First one is ESP
-      doAddEFIBootEntry: true
+      #doAddEFIBootEntry: true
+      doRestoreGRUBNormalcy: true
 
 
 # Generates CRs triplets with Hardware, Workflow, and Template, using by-id references to the hook and images above.

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -18,8 +18,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240419-1740/"
-    hookDownloadId: "20240419-1740" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240519-1405/"
+    hookDownloadId: "20240519-1405" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
@@ -28,7 +28,7 @@ provision:
     "default-hook-amd64":
       enabled: false
       arch: "x86_64"
-      downloadFile: "hook-x86_64.tar.gz"
+      downloadFile: "hook_x86_64.tar.gz"
       kernel: "vmlinuz-x86_64"
       initrd: "initramfs-x86_64"
       kernelCommandLine: ""
@@ -37,7 +37,7 @@ provision:
     "latest-lts-amd64":
       enabled: false
       arch: "x86_64"
-      downloadFile: "hook-latest-lts-x86_64.tar.gz"
+      downloadFile: "hook_latest-lts-x86_64.tar.gz"
       kernel: "vmlinuz-latest-lts-x86_64"
       initrd: "initramfs-latest-lts-x86_64"
       kernelCommandLine: ""
@@ -46,7 +46,7 @@ provision:
     "peg-default-amd64":
       enabled: false
       arch: "x86_64"
-      downloadFile: "hook-peg-default-amd64.tar.gz"
+      downloadFile: "hook_peg-default-amd64.tar.gz"
       kernel: "vmlinuz-peg-default-amd64"
       initrd: "initramfs-peg-default-amd64"
       kernelCommandLine: ""
@@ -56,7 +56,7 @@ provision:
       enabled: false
       skipDownload: true # Don't download it, it's already there; just enable it
       arch: "x86_64"
-      downloadFile: "hook-x86_64.tar.gz"
+      downloadFile: "hook_x86_64.tar.gz"
       kernel: "vmlinuz-x86_64"
       initrd: "initramfs-x86_64"
       kernelCommandLine: ""
@@ -66,7 +66,7 @@ provision:
     "default-hook-aarch64":
       enabled: false
       arch: "aarch64"
-      downloadFile: "hook-aarch64.tar.gz"
+      downloadFile: "hook_aarch64.tar.gz"
       kernel: "vmlinuz-aarch64"
       initrd: "initramfs-aarch64"
       kernelCommandLine: ""
@@ -75,7 +75,7 @@ provision:
     "latest-lts-aarch64":
       enabled: false
       arch: "aarch64"
-      downloadFile: "hook-latest-lts-aarch64.tar.gz"
+      downloadFile: "hook_latest-lts-aarch64.tar.gz"
       kernel: "vmlinuz-latest-lts-aarch64"
       initrd: "initramfs-latest-lts-aarch64"
       kernelCommandLine: ""
@@ -84,7 +84,7 @@ provision:
     "armbian-uefi-x86-edge":
       enabled: false
       arch: "x86_64"
-      downloadFile: "hook-armbian-uefi-x86-edge.tar.gz"
+      downloadFile: "hook_armbian-uefi-x86-edge.tar.gz"
       kernel: "vmlinuz-armbian-uefi-x86-edge"
       initrd: "initramfs-armbian-uefi-x86-edge"
       kernelCommandLine: "intel_iommu=on iommu=pt"
@@ -94,7 +94,7 @@ provision:
     "armbian-uefi-arm64-edge":
       enabled: false
       arch: "aarch64"
-      downloadFile: "hook-armbian-uefi-arm64-edge.tar.gz"
+      downloadFile: "hook_armbian-uefi-arm64-edge.tar.gz"
       kernel: "vmlinuz-armbian-uefi-arm64-edge"
       initrd: "initramfs-armbian-uefi-arm64-edge"
       kernelCommandLine: ""
@@ -103,7 +103,7 @@ provision:
     "armbian-meson64-edge":
       enabled: false
       arch: "aarch64"
-      downloadFile: "hook-armbian-meson64-edge.tar.gz"
+      downloadFile: "hook_armbian-meson64-edge.tar.gz"
       kernel: "vmlinuz-armbian-meson64-edge"
       initrd: "initramfs-armbian-meson64-edge"
       kernelCommandLine: "acpi=off efi=noruntime"
@@ -112,7 +112,7 @@ provision:
     "armbian-rockchip64-edge":
       enabled: false
       arch: "aarch64"
-      downloadFile: "hook-armbian-rockchip64-edge.tar.gz"
+      downloadFile: "hook_armbian-rockchip64-edge.tar.gz"
       kernel: "vmlinuz-armbian-rockchip64-edge"
       initrd: "initramfs-armbian-rockchip64-edge"
       kernelCommandLine: ""
@@ -121,7 +121,7 @@ provision:
     "armbian-bcm2711-current":
       enabled: false
       arch: "aarch64"
-      downloadFile: "hook-armbian-bcm2711-current.tar.gz"
+      downloadFile: "hook_armbian-bcm2711-current.tar.gz"
       kernel: "vmlinuz-armbian-bcm2711-current"
       initrd: "initramfs-armbian-bcm2711-current"
       kernelCommandLine: ""
@@ -130,7 +130,7 @@ provision:
     "armbian-rk35xx-vendor":
       enabled: false
       arch: "aarch64"
-      downloadFile: "hook-armbian-rk35xx-vendor.tar.gz"
+      downloadFile: "hook_armbian-rk35xx-vendor.tar.gz"
       kernel: "vmlinuz-armbian-rk35xx-vendor"
       initrd: "initramfs-armbian-rk35xx-vendor"
       kernelCommandLine: "" # acpi=off efi=noruntime splash=verbose
@@ -139,7 +139,7 @@ provision:
     "armbian-rk3588-edge":
       enabled: false
       arch: "aarch64"
-      downloadFile: "hook-armbian-rk3588-edge.tar.gz"
+      downloadFile: "hook_armbian-rk3588-edge.tar.gz"
       kernel: "vmlinuz-armbian-rk3588-edge"
       initrd: "initramfs-armbian-rk3588-edge"
       kernelCommandLine: "" # acpi=off efi=noruntime splash=verbose
@@ -148,7 +148,7 @@ provision:
     "armbian-rk35xx-legacy":
       enabled: false
       arch: "aarch64"
-      downloadFile: "hook-armbian-rk35xx-legacy.tar.gz"
+      downloadFile: "hook_armbian-rk35xx-legacy.tar.gz"
       kernel: "vmlinuz-armbian-rk35xx-legacy"
       initrd: "initramfs-armbian-rk35xx-legacy"
       kernelCommandLine: "" # acpi=off efi=noruntime splash=verbose

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -138,6 +138,27 @@ provision:
       doGrowPart: true
       doUserAndSshSetup: true
       rootfsPartitionNumber: "1"
+      
+    "armbian-uefi-arm64-edge-cloud-k8s":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.04.04-armsurvivors-86/Armbian-unofficial_24.04.04-armsurvivors-86_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
+      image: "Armbian-unofficial_24.04.04-armsurvivors-86_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.gz"
+      conversion: "xz-to-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      rootfsPartitionNumber: "2" #  1 is ESP, 2 rootfs
+      
+    "armbian-uefi-x86-edge-cloud-k8s":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.04.04-armsurvivors-86/Armbian-unofficial_24.04.04-armsurvivors-86_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
+      image: "Armbian-unofficial_24.04.04-armsurvivors-86_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.gz"
+      conversion: "xz-to-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      rootfsPartitionNumber: "2" #  1 is ESP, 2 rootfs
+      
     
     "armbian-rpardini-rockpro64-edge-uboot":
       enabled: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -94,7 +94,7 @@ provision:
       downloadFile: "hook-armbian-rk35xx-vendor.tar.gz"
       kernel: "vmlinuz-armbian-rk35xx-vendor"
       initrd: "initramfs-armbian-rk35xx-vendor"
-      kernelCommandLine: "acpi=off efi=noruntime splash=verbose"
+      kernelCommandLine: "" # acpi=off efi=noruntime splash=verbose
       bootMode: reboot
     
     "armbian-rk35xx-legacy":
@@ -169,6 +169,16 @@ provision:
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
       rootfsPartitionNumber: "1" # first partition, ext4 rootfs 
+    
+    "armbian-rpardini-r58x-vendor-uefi-cloud": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.03.31-armsurvivors-68/Armbian-unofficial_24.03.31-armsurvivors-68_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.xz"
+      image: "Armbian-unofficial_24.03.31-armsurvivors-68_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.gz"
+      conversion: "xz-to-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      rootfsPartitionNumber: "2" # first partition is ESP, 2nd is ext4 rootfs 
     
     "armbian-bookworm-meson64-current-cloud":
       enabled: false
@@ -302,10 +312,10 @@ hardware:
     "mekotronics-r58x-pro-via-usb":
       enabled: false
       arch: aarch64
-      mac: "3c:18:a0:15:9a:9f" # 3C18A0159A9F
+      mac: "3c:18:a0:15:9a:9f" # 3C18A0159A9F 
+      rootDisk: "/dev/nvme0NOENOENOENEyet"
       ipv4:
         address: "192.168.99.55"
-      hookRef: "armbian-rk35xx-legacy" # "armbian-rk35xx-vendor"
-      imageRef: "armbian-rpardini-r58x-vendor-uboot"
-      extraKernelCommandLine: "console=ttyFIQ0:1500000 " # console=tty1  # Last console defined "wins", thus use tty1 last if no serial console
-      rootDisk: "/dev/nvme0NOENOENOENEyet"
+      hookRef: "armbian-rk35xx-vendor"
+      imageRef: "armbian-rpardini-r58x-vendor-uefi-cloud" # "armbian-rpardini-r58x-vendor-uboot"
+      extraKernelCommandLine: "console=tty1 console=ttyFIQ0,1500000 " #    # Last console defined "wins", thus use tty1 last if no serial console

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -18,8 +18,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240603-0515/"
-    hookDownloadId: "20240603-0515" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240604-0609/"
+    hookDownloadId: "20240604-0609" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -18,8 +18,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240520-0729/"
-    hookDownloadId: "20240520-0729" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240520-0941/"
+    hookDownloadId: "20240520-0941" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -3,6 +3,7 @@ tinkerbell:
   hostDirectory: "/opt/hook" # hostPath where Hook & images are downloaded & served from
   hookURL: "http://192.168.66.71:8080" # # URL where Hook is served from
   imagesURL: "http://192.168.66.71:8080" # # URL where images are served from
+  hegelURL: "http://192.168.66.71:32061" # Hegel URL
   syslogHost: "192.168.66.71" # Syslog host, usually smee
   grpcAuthority: "192.168.66.71:42113" # Tink's gRPC authority
 
@@ -166,6 +167,7 @@ provision:
       doGrowPart: true
       doUserAndSshSetup: true
       doFixResolvConf: true
+      doInjectHegelCloudInit: true
       rootfsPartitionNumber: "1" # @schema type:[integer] # @TODO fix so this mustn't be a string
 
     "ubuntu-jammy-cloud-amd64":
@@ -177,6 +179,7 @@ provision:
       doGrowPart: true
       doUserAndSshSetup: true
       doFixResolvConf: true
+      doInjectHegelCloudInit: true
       rootfsPartitionNumber: "1"
     
     "fatso-ubuntu-noble-baremetal-amd64":
@@ -188,6 +191,7 @@ provision:
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false
+      doInjectHegelCloudInit: true
       rootfsPartitionNumber: "2" # First one is ESP
     
     "fatso-rocky8-baremetal-amd64":
@@ -210,6 +214,7 @@ provision:
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false
+      doInjectHegelCloudInit: true
       rootfsPartitionNumber: "2" # First one is ESP
     
     "fatso-rocky8-local-amd64":
@@ -407,6 +412,10 @@ hardware:
       hookRef: "default-hook-amd64"
       imageRef: "fatso-ubuntu-noble-baremetal-amd64"
       extraKernelCommandLine: "console=ttyS0"
+      # userData is just standard cloud-init, thus supports #cloud-config and #include etc.
+      # Attention: if ever ran, this gives rpardini root access to your machine. Use your own scripts;
+      userData: |
+        #include https://cloud-init.pardini.net/rpardini/oldskool-rpardini/master/base
 
     "vm09":
       enabled: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -17,8 +17,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240404-2216/"
-    hookDownloadId: "20240404-2216" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240413-0904/"
+    hookDownloadId: "20240413-0904" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
@@ -32,6 +32,45 @@ provision:
       initrd: "initramfs-x86_64"
       kernelCommandLine: ""
       bootMode: reboot # @TODO: this needs to be set per-device & per-image as well # kexec
+
+    "peg-default-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadFile: "hook-peg-default-amd64.tar.gz"
+      kernel: "vmlinuz-peg-default-amd64"
+      initrd: "initramfs-peg-default-amd64"
+      kernelCommandLine: ""
+      bootMode: reboot
+
+    "pegk-default-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadFile: "hook-pegk-default-amd64.tar.gz"
+      kernel: "vmlinuz-pegk-default-amd64"
+      initrd: "initramfs-pegk-default-amd64"
+      kernelCommandLine: ""
+      bootMode: reboot
+
+    "dev-pegk-default-amd64":
+      enabled: false
+      skipDownload: true # Don't download it, it's already there; just enable it
+      arch: "x86_64"
+      downloadFile: "hook-pegk-default-amd64.tar.gz"
+      kernel: "vmlinuz-pegk-default-amd64"
+      initrd: "initramfs-pegk-default-amd64"
+      kernelCommandLine: ""
+      bootMode: reboot
+
+    "dev-default-hook-amd64":
+      enabled: false
+      skipDownload: true # Don't download it, it's already there; just enable it
+      arch: "x86_64"
+      downloadFile: "hook-x86_64.tar.gz"
+      kernel: "vmlinuz-x86_64"
+      initrd: "initramfs-x86_64"
+      kernelCommandLine: ""
+      bootMode: reboot
+
 
     "default-hook-aarch64":
       enabled: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -141,6 +141,28 @@ provision:
       doFixResolvConf: true
       rootfsPartitionNumber: "1"
     
+    "fatso-ubuntu-noble-baremetal-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal/ubuntu-noble-baremetal-v1000.img.gz"
+      conversion: "download-only"
+      image: "ubuntu-noble-baremetal-v1000.img.gz"
+      doGrowPart: false
+      doUserAndSshSetup: false
+      doFixResolvConf: false
+      rootfsPartitionNumber: "2" # First one is ESP
+    
+    "fatso-ubuntu-noble-local-amd64":
+      enabled: false
+      arch: "x86_64"
+      downloadURL: "not-used-but-must-change-if-image-changes"
+      conversion: "local" # should be there already somehow
+      image: "ubuntu-noble-baremetal-v1000-local.img.gz"
+      doGrowPart: false
+      doUserAndSshSetup: false
+      doFixResolvConf: false
+      rootfsPartitionNumber: "2" # First one is ESP
+    
     "armbian-uefi-arm64-edge-cloud-k8s":
       enabled: false
       arch: "aarch64"
@@ -303,6 +325,17 @@ hardware:
       hookRef: "default-hook-aarch64"
       imageRef: "ubuntu-jammy-cloud-arm64" # defined above
       extraKernelCommandLine: "console=ttyAMA0"
+
+    "vm08":
+      enabled: false
+      arch: x86_64
+      mac: "52:54:00:01:03:08"
+      rootDisk: "/dev/disk/by-id/virtio-root_disk_serial"
+      ipv4:
+        address: "192.168.99.59"
+      hookRef: "default-hook-amd64"
+      imageRef: "fatso-ubuntu-noble-baremetal-amd64"
+      extraKernelCommandLine: "console=ttyS0"
 
     "vm09":
       enabled: false

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -185,9 +185,9 @@ provision:
     "fatso-ubuntu-noble-baremetal-amd64":
       enabled: false
       arch: "x86_64"
-      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal-cloud-k8s-nvidia/ubuntu-noble-baremetal-cloud-k8s-nvidia-v1004.img.gz"
+      downloadURL: "https://github.com/k8s-avengers/fatso-images/releases/download/ubuntu-noble-baremetal-cloud-k8s-nvidia/ubuntu-noble-baremetal-cloud-k8s-nvidia-v1005.img.gz"
       conversion: "download-only"
-      image: "ubuntu-noble-baremetal-cloud-k8s-nvidia-v1004.img.gz"
+      image: "ubuntu-noble-baremetal-cloud-k8s-nvidia-v1005.img.gz"
       doGrowPart: false
       doUserAndSshSetup: false
       doFixResolvConf: false
@@ -242,8 +242,8 @@ provision:
     "armbian-rpardini-orangepi3b-edge-uboot":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.04.06-armsurvivors-90/Armbian-unofficial_24.04.06-armsurvivors-90_Orangepi3b_bookworm_edge_6.8.4.img.xz"
-      image: "Armbian-unofficial_24.04.06-armsurvivors-90_Orangepi3b_bookworm_edge_6.8.4.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.12-armsurvivors-166/Armbian-unofficial_24.05.12-armsurvivors-166_Orangepi3b_bookworm_edge_6.8.9.img.xz"
+      image: "Armbian-unofficial_24.05.12-armsurvivors-166_Orangepi3b_bookworm_edge_6.8.9.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted

--- a/tinkerbell/showcase/values.yaml
+++ b/tinkerbell/showcase/values.yaml
@@ -18,8 +18,8 @@ provision:
   common:
     # Used together with downloadFile field in each hook;
     # Check https://github.com/rpardini/tinkerbell-hook/releases/ for updates
-    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240520-0941/"
-    hookDownloadId: "20240520-0941" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
+    hookDownloadBaseURL: "https://github.com/rpardini/tinkerbell-hook/releases/download/20240522-1109/"
+    hookDownloadId: "20240522-1109" # If the ID changes, all hooks will be re-downloaded. Can't contain slashes or spaces
   
   # Define one key per hook built to be downloaded and made available. Those _must_ match the hardware definitions.
   # Important: each definition will be auto-enabled when they're referenced in an enabled device. You can force them enabled: true
@@ -208,8 +208,8 @@ provision:
     "armbian-uefi-arm64-edge-cloud-k8s":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
-      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-189_Uefi-arm64_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.gz"
       conversion: "xz-qcow2-to-img-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -219,8 +219,8 @@ provision:
     "armbian-uefi-x86-edge-cloud-k8s":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
-      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.qcow2.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-189_Uefi-x86_bookworm_edge_6.8.4-metadata-cloud-k8s-1.28.img.gz"
       conversion: "xz-qcow2-to-img-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -231,8 +231,8 @@ provision:
     "armbian-rpardini-rockpro64-edge-uboot":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Rockpro64_bookworm_edge_6.8.2.img.xz"
-      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Rockpro64_bookworm_edge_6.8.2.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Rockpro64_bookworm_edge_6.8.2.img.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-189_Rockpro64_bookworm_edge_6.8.2.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -242,8 +242,8 @@ provision:
     "armbian-rpardini-orangepi3b-edge-uboot":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Orangepi3b_bookworm_edge_6.8.9.img.xz"
-      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Orangepi3b_bookworm_edge_6.8.9.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Orangepi3b_bookworm_edge_6.8.9.img.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-189_Orangepi3b_bookworm_edge_6.8.9.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -253,8 +253,8 @@ provision:
     "armbian-rpardini-t95z-cloud-edge-uboot":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_T95z_bookworm_edge_6.8.10-metadata-cloud.img.qcow2.xz"
-      image: "Armbian-unofficial_24.05.20-armsurvivors-184_T95z_bookworm_edge_6.8.10-metadata-cloud.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Aml-t95z-plus_bookworm_edge_6.8.10-metadata-cloud.img.qcow2.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-189_Aml-t95z-plus_bookworm_edge_6.8.10-metadata-cloud.img.gz"
       conversion: "xz-qcow2-to-img-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -262,22 +262,35 @@ provision:
       doInjectHegelCloudInit: true
       rootfsPartitionNumber: "1" # rootfs is the one and only
     
-    "armbian-rpardini-rpi4b-current-not-efi":
+    "armbian-rpardini-odroidhc4-cloud-uboot":
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Rpi4b_bookworm_current_6.6.23.img.xz"
-      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Rpi4b_bookworm_current_6.6.23.img.gz"
-      conversion: "xz-to-gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Odroidhc4_bookworm_edge_6.8.10-metadata-cloud.img.qcow2.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-189_Odroidhc4_bookworm_edge_6.8.10-metadata-cloud.img.gz"
+      conversion: "xz-qcow2-to-img-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
       doFixResolvConf: true
+      doInjectHegelCloudInit: true
+      rootfsPartitionNumber: "1" # rootfs is the one and only
+    
+    "armbian-rpardini-rpi4b-cloud-notefi":
+      enabled: false
+      arch: "aarch64"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-190/Armbian-unofficial_24.05.22-armsurvivors-190_Rpi4b_bookworm_current_6.6.31-metadata-cloud.img.qcow2.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-190_Rpi4b_bookworm_current_6.6.31-metadata-cloud.img.gz"
+      conversion: "xz-qcow2-to-img-gz"
+      doGrowPart: false # Armbian does it itself when booted
+      doUserAndSshSetup: false # Armbian does it itself when booted
+      doFixResolvConf: true
+      doInjectHegelCloudInit: true
       rootfsPartitionNumber: "2" # rpi image has a fat32 boot partition (config.txt and such), and partition 2 is the real ext4 rootfs
     
     "armbian-rpardini-r58x-vendor-uboot": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.xz"
-      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-189_Mekotronics-r58x-pro_bookworm_vendor_6.1.43.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -287,8 +300,8 @@ provision:
     "armbian-rpardini-r58x-vendor-uefi-cloud": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.xz"
-      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-189_Mekotronics-r58x-pro_jammy_vendor_6.1.43-cloud-amazingfated-edk2-custom-userdata.img.gz"
       conversion: "xz-to-gz"
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -298,8 +311,8 @@ provision:
     "rock-5b-edge-trixie-uefi-dtb": # @TODO this is the wrong thing to use. we need a generic EFI-enabled image without forcing DTB. Same for all the others!
       enabled: false
       arch: "aarch64"
-      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.20-armsurvivors-184/Armbian-unofficial_24.05.20-armsurvivors-184_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.xz"
-      image: "Armbian-unofficial_24.05.20-armsurvivors-184_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.gz"
+      downloadURL: "https://github.com/armsurvivors/armbian-release/releases/download/24.05.22-armsurvivors-189/Armbian-unofficial_24.05.22-armsurvivors-189_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.xz"
+      image: "Armbian-unofficial_24.05.22-armsurvivors-189_Rock-5b_trixie_edge_6.8.4-cloud-edk2-custom-userdata.img.gz"
       conversion: "xz-to-gz" # @TODO: "qcow2-xz-to-img-gz" one day for completeness
       doGrowPart: false # Armbian does it itself when booted
       doUserAndSshSetup: false # Armbian does it itself when booted
@@ -455,6 +468,17 @@ hardware:
       imageRef: "armbian-rpardini-t95z-cloud-edge-uboot"
       extraKernelCommandLine: "console=ttyAML0,115200"
     
+    "odroidhc4":
+      enabled: false
+      arch: aarch64
+      mac: "00:1e:06:49:15:91"
+      rootDisk: "/dev/sda" # SATA Disk plugged in
+      ipv4:
+        address: "192.168.99.28"
+      hookRef: "armbian-meson64-edge"
+      imageRef: "armbian-rpardini-odroidhc4-cloud-uboot"
+      extraKernelCommandLine: "console=ttyAML0,115200"
+    
     # RockPro64 and other rockchip64-based boards (u-boot)
     "rockpro64":
       enabled: false
@@ -488,7 +512,7 @@ hardware:
       ipv4:
         address: "192.168.99.54"
       hookRef: "armbian-bcm2711-current" # works, as long as UEFI is set with ACPI+DTB and no 3gb limit. Use edk2 from https://github.com/pftf/RPi4
-      imageRef: "armbian-rpardini-rpi4b-current-not-efi" # defined above
+      imageRef: "armbian-rpardini-rpi4b-cloud-notefi"
       extraKernelCommandLine: "console=tty1 console=ttyAMA0,115200 loglevel=7" # Last console defined "wins", thus use tty1 last if no serial console
 
     "mekotronics-r58x-pro-via-usb":

--- a/tinkerbell/stack/templates/hook.yaml
+++ b/tinkerbell/stack/templates/hook.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.stack.hook.enabled }}
+{{- if .Values.stack.hook.downloadEnabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -41,7 +42,7 @@ spec:
       containers:
         - name: download-hook
           image: {{ .Values.stack.hook.image }}
-          command: ["/script/entrypoint.sh"]
+          command: [ "/script/entrypoint.sh" ]
           volumeMounts:
             - mountPath: /output
               name: hook-artifacts
@@ -57,4 +58,5 @@ spec:
           configMap:
             defaultMode: 0700
             name: download-hook
+{{- end }}
 {{- end }}

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -24,6 +24,7 @@ stack:
     # downloadURL only works with the > 0.8.1 Hook release because
     # previous Hook versions didn't provide a checksum file.
     downloadURL: https://github.com/tinkerbell/hook/releases/download/latest
+    downloadEnabled: true # Set to false if you somehow download Hook manually; if set to True will include a download Job
   kubevip:
     enabled: true
     name: kube-vip

--- a/tinkerbell/suite/Chart.yaml
+++ b/tinkerbell/suite/Chart.yaml
@@ -20,6 +20,6 @@ dependencies:
 
   # showcase chart!
   - name: showcase
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "file://../showcase"
     condition: showcase.enabled

--- a/tinkerbell/suite/Chart.yaml
+++ b/tinkerbell/suite/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: "0.2.3"
     repository: "file://../tink"
   - name: smee
-    version: "0.3.2"
+    version: "0.3.3"
     repository: "file://../smee"
   - name: rufio
     version: "0.2.8"

--- a/tinkerbell/suite/Chart.yaml
+++ b/tinkerbell/suite/Chart.yaml
@@ -6,16 +6,16 @@ version: 0.0.1
 
 dependencies:
   - name: tink
-    version: "0.2.3"
+    version: "0.2.4"
     repository: "file://../tink"
   - name: smee
-    version: "0.3.3"
+    version: "0.3.4"
     repository: "file://../smee"
   - name: rufio
-    version: "0.2.8"
+    version: "0.2.9"
     repository: "file://../rufio"
   - name: hegel
-    version: "0.3.4"
+    version: "0.3.5"
     repository: "file://../hegel"
 
   # showcase chart!

--- a/tinkerbell/suite/Chart.yaml
+++ b/tinkerbell/suite/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: suite
+description: A batteries-included Helm chart for Tinkerbell on a single node cluster using that host's network and NodePort services
+type: application
+version: 0.0.1
+
+dependencies:
+  - name: tink
+    version: "0.2.3"
+    repository: "file://../tink"
+  - name: smee
+    version: "0.3.2"
+    repository: "file://../smee"
+  - name: rufio
+    version: "0.2.8"
+    repository: "file://../rufio"
+  - name: hegel
+    version: "0.3.4"
+    repository: "file://../hegel"
+
+  # showcase chart!
+  - name: showcase
+    version: "0.0.1"
+    repository: "file://../showcase"
+    condition: showcase.enabled

--- a/tinkerbell/suite/templates/hook-server.yaml
+++ b/tinkerbell/suite/templates/hook-server.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.hookImageServer.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "hook-image-server-nginx-conf"
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  nginx.conf: |
+    worker_processes 1;
+    events {
+        worker_connections  1024;
+    }
+    user root;
+    http {
+       server {
+        listen 3000;
+        location / {
+          sendfile           on;
+          sendfile_max_chunk 1m;
+          root /usr/share/nginx/html;
+          autoindex on;
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hook-image-server
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  selector:
+    matchLabels:
+      app: hook-image-server
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum: "@TODO" # @TODO hash like download jobs
+      labels:
+        app: hook-image-server
+    spec:
+      containers:
+        - name: hook-image-server
+          image: nginx:1
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+              name: http
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          volumeMounts:
+            - mountPath: /etc/nginx
+              readOnly: true
+              name: nginx-conf
+            - mountPath: /usr/share/nginx/html
+              name: hook-artifacts
+              readOnly: true
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: "hook-image-server-nginx-conf"
+            items:
+              - key: nginx.conf
+                path: nginx.conf
+        - name: hook-artifacts
+          hostPath:
+            path: {{ .Values.showcase.tinkerbell.hostDirectory }}
+            type: DirectoryOrCreate
+{{- end }}

--- a/tinkerbell/suite/templates/nodeport-hegel.yaml
+++ b/tinkerbell/suite/templates/nodeport-hegel.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   ports:
     - name: hegel-http
       nodePort: {{ .Values.nodePort.hegel.port }}

--- a/tinkerbell/suite/templates/nodeport-hegel.yaml
+++ b/tinkerbell/suite/templates/nodeport-hegel.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.nodePort.hegel.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hegel
+  name: hegel-nodeport
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: NodePort
+  ports:
+    - name: hegel-http
+      nodePort: {{ .Values.nodePort.hegel.port }}
+      protocol: TCP
+      port: 50061
+      targetPort: hegel-http
+  selector:
+    app: hegel
+{{- end }}

--- a/tinkerbell/suite/templates/nodeport-hook-image-server.yaml
+++ b/tinkerbell/suite/templates/nodeport-hook-image-server.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.nodePort.hookImageServer.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hook-image-server
+  name: hook-image-server-nodeport
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 3000
+      nodePort: {{ .Values.nodePort.hookImageServer.port }}
+      protocol: TCP
+  selector:
+    app: hook-image-server
+{{- end }}

--- a/tinkerbell/suite/templates/nodeport-hook-image-server.yaml
+++ b/tinkerbell/suite/templates/nodeport-hook-image-server.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   ports:
     - name: http
       port: 3000

--- a/tinkerbell/suite/templates/nodeport-tink-grpc.yaml
+++ b/tinkerbell/suite/templates/nodeport-tink-grpc.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.nodePort.tinkGRPC.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tink-server
+  name: tink-grpc-nodeport
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: NodePort
+  ports:
+    - name: tink-grpc
+      nodePort: {{ .Values.nodePort.tinkGRPC.port }}
+      protocol: TCP
+      port: 42113
+      targetPort: tink-grpc
+  selector:
+    app: tink-server
+{{- end }}

--- a/tinkerbell/suite/templates/nodeport-tink-grpc.yaml
+++ b/tinkerbell/suite/templates/nodeport-tink-grpc.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   ports:
     - name: tink-grpc
       nodePort: {{ .Values.nodePort.tinkGRPC.port }}

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -219,7 +219,8 @@ smee:
   logLevel: "debug"
   tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.10.0
   #image: quay.io/tinkerbellrpardini/smee:latest-rpardini5 # custom build with updated ipxedust; some DTBs; pxelinux.cfg
-  image: quay.io/tinkerbellrpardini/smee:latest-rpardini8 # custom build with updated ipxedust; some DTBs; pxelinux.cfg; HC4 DT; rebased vs upstream/main after a long while
+  #image: quay.io/tinkerbellrpardini/smee:latest-rpardini8 # custom build with updated ipxedust; some DTBs; pxelinux.cfg; HC4 DT; rebased vs upstream/main after a long while
+  image: quay.io/tinkerbellrpardini/smee:latest-rpardini10 # custom build with updated ipxedust; some DTBs; pxelinux.cfg; +T6/CM3588-NAS DTs; rebased vs upstream/main 20240608
   # @TODO bug in smee chart, the values is under http: but the usage is not
   trustedProxies: [ "0.0.0.0/0" ] # Trust _all_ proxies, insecure
   publicIP: 192.168.99.2 # Must be set

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -22,7 +22,7 @@ nodePort:
   hookImageServer:
     enabled: true
     port: 32083
-  hegel: # @TODO this nodeport template
+  hegel:
     enabled: true
     port: 32061
   tinkGRPC:
@@ -170,9 +170,6 @@ smee:
 hegel:
   image: quay.io/tinkerbell/hegel:v0.12.0
   trustedProxies: [ "0.0.0.0/0" ] # Trust _all_ proxies, insecure
-  nodePort:
-    enabled: true
-    port: 50061
 
 rufio:
   image: quay.io/tinkerbell/rufio:v0.3.3

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -39,6 +39,7 @@ showcase:
         gateway: "192.168.99.1" # Must be set, otherwise no internet access; can be overriden per-device
         netmask: "255.255.255.0"
         dns: [ "192.168.66.1" ]
+        time_servers: [ "192.168.66.1" ]
 
     devices:
       ####  Examples for use in Hook development environment.
@@ -195,7 +196,7 @@ smee:
   hostNetwork: true # no proxies, loadbalancers, or anything: it just runs as if directly on the k8s host.
   logLevel: "debug"
   tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.10.0
-  image: quay.io/tinkerbellrpardini/smee:latest-rpardini4 # custom build with updated ipxedust and arm64 NAPNULL for u-boot's PXE-via-EFI
+  image: quay.io/tinkerbellrpardini/smee:latest-rpardini5 # custom build with updated ipxedust and arm64 NAPNULL for u-boot's PXE-via-EFI
   # @TODO bug in smee chart, the values is under http: but the usage is not
   trustedProxies: [ "0.0.0.0/0" ] # Trust _all_ proxies, insecure
   publicIP: 192.168.99.2 # Must be set

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -47,10 +47,10 @@ showcase:
       ####  `export MAC=11:22:33:44:55:66 TINK_SERVER=x.y.z.y` can be used with the below "machines".
       ####  The MAC address is not really used by the qemu VM, but is passed via kernel cmdline.
       "run-qemu-x86":
-        enabled: true
+        enabled: false
         mac: "11:22:33:44:55:66"
       "run-qemu-arm64":
-        enabled: true
+        enabled: false
         mac: "11:22:33:44:55:77"
       
       
@@ -74,7 +74,7 @@ showcase:
           address: "192.168.99.41"
 
       "vm08":
-        enabled: true
+        enabled: false
         arch: x86_64
         mac: "52:54:00:01:03:08"
         rootDisk: "/dev/disk/by-id/virtio-root_disk_serial"
@@ -90,7 +90,7 @@ showcase:
         #  bootMode: kexec
 
       "vm09":
-        enabled: true
+        enabled: false
         arch: x86_64
         mac: "52:54:00:01:03:09"
         rootDisk: "/dev/disk/by-id/virtio-root_disk_serial"
@@ -104,7 +104,7 @@ showcase:
       
       
       "thundercat":
-        enabled: true
+        enabled: false
         arch: x86_64
         #mac: "3c:18:a0:15:9a:9f" # thinkpad 100mbit/s?
         #mac: "8c:ae:4c:dd:10:78" # 2.5gbit plugable
@@ -149,7 +149,7 @@ showcase:
           address: "192.168.99.51"
 
       "t95z":
-        enabled: true
+        enabled: false
         arch: aarch64
         mac: "ea:da:5c:76:8d:09"
         rootDisk: "/dev/sda" # USB Disk plugged in
@@ -158,6 +158,15 @@ showcase:
         userData: |
           #include https://cloud-init.pardini.net/rpardini/oldskool-rpardini/master/base
       
+      "odroidhc4":
+        enabled: false
+        arch: aarch64
+        mac: "00:1e:06:49:15:91"
+        rootDisk: "/dev/sda" # SATA Disk plugged in
+        ipv4:
+          address: "192.168.99.28"
+        userData: |
+          #include https://cloud-init.pardini.net/rpardini/oldskool-rpardini/master/base
       
       # RockPro64 and other rockchip64-based boards (u-boot)
       "rockpro64":
@@ -179,9 +188,11 @@ showcase:
       "rpi4b":
         enabled: false
         mac: "dc:a6:32:ec:8b:49"
-        rootDisk: "/dev/disk/by-id/wwn-0x3001237923792379"
+        rootDisk: "/dev/disk/by-id/wwn-0x3001237923792379" # a specific USB disk, by-id.
         ipv4:
           address: "192.168.99.54"
+        userData: |
+          #include https://cloud-init.pardini.net/rpardini/oldskool-rpardini/master/base
       
       "mekotronics-r58x-pro-via-usb":
         enabled: false
@@ -207,7 +218,8 @@ smee:
   hostNetwork: true # no proxies, loadbalancers, or anything: it just runs as if directly on the k8s host.
   logLevel: "debug"
   tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.10.0
-  image: quay.io/tinkerbellrpardini/smee:latest-rpardini5 # custom build with updated ipxedust and arm64 NAPNULL for u-boot's PXE-via-EFI
+  #image: quay.io/tinkerbellrpardini/smee:latest-rpardini5 # custom build with updated ipxedust; some DTBs; pxelinux.cfg
+  image: quay.io/tinkerbellrpardini/smee:latest-rpardini8 # custom build with updated ipxedust; some DTBs; pxelinux.cfg; HC4 DT; rebased vs upstream/main after a long while
   # @TODO bug in smee chart, the values is under http: but the usage is not
   trustedProxies: [ "0.0.0.0/0" ] # Trust _all_ proxies, insecure
   publicIP: 192.168.99.2 # Must be set

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -47,10 +47,10 @@ showcase:
       ####  `export MAC=11:22:33:44:55:66 TINK_SERVER=x.y.z.y` can be used with the below "machines".
       ####  The MAC address is not really used by the qemu VM, but is passed via kernel cmdline.
       "run-qemu-x86":
-        enabled: false
+        enabled: true
         mac: "11:22:33:44:55:66"
       "run-qemu-arm64":
-        enabled: false
+        enabled: true
         mac: "11:22:33:44:55:77"
       
       
@@ -129,10 +129,10 @@ showcase:
         #hookRef: "dev-default-hook-amd64" # "default-hook-amd64" # defined above
 
         #imageRef: "fatso-el9-local-amd64"
-        imageRef: "fatso-ubuntu-noble-local-amd64"
+        #imageRef: "fatso-ubuntu-noble-local-amd64"
         #imageRef: "fatso-rocky8-baremetal-amd64"
         #imageRef: "fatso-rocky8-local-amd64"
-        #imageRef: "fatso-ubuntu-noble-baremetal-amd64"
+        imageRef: "fatso-ubuntu-noble-baremetal-amd64"
         #imageRef: "fatso-ubuntu-noble-local-amd64"
       
       
@@ -147,6 +147,17 @@ showcase:
         rootDisk: "/dev/mmcblk0"
         ipv4:
           address: "192.168.99.51"
+
+      "t95z":
+        enabled: true
+        arch: aarch64
+        mac: "ea:da:5c:76:8d:09"
+        rootDisk: "/dev/sda" # USB Disk plugged in
+        ipv4:
+          address: "192.168.99.27"
+        userData: |
+          #include https://cloud-init.pardini.net/rpardini/oldskool-rpardini/master/base
+      
       
       # RockPro64 and other rockchip64-based boards (u-boot)
       "rockpro64":
@@ -160,7 +171,7 @@ showcase:
       "orangepi3b":
         enabled: false
         mac: "b6:a7:96:d5:f1:84"
-        rootDisk: "/dev/disk/by-id/wwn-0x3001237923792379" # /dev/mmcblk0 is the eMMC
+        rootDisk: "/dev/sda" # usb disk # "/dev/disk/by-id/wwn-0x3001237923792379" # /dev/mmcblk0 is the eMMC
         ipv4:
           address: "192.168.99.53"
       

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -152,7 +152,8 @@ showcase:
     syslogHost: "192.168.99.2"
     # tink's grpc nodeport
     grpcAuthority: "192.168.99.2:32013"
-    # @TODO one day use hegel to serve user-data and meta-data to _deployed cloud-init images_
+    # Hegel nodeport
+    hegelURL: "http://192.168.99.2:32061"
 
 smee:
   hostNetwork: true # no proxies, loadbalancers, or anything: it just runs as if directly on the k8s host.

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -163,6 +163,9 @@ smee:
   trustedProxies: [ "0.0.0.0/0" ] # Trust _all_ proxies, insecure
   publicIP: 192.168.99.2 # Must be set
   imagePullPolicy: Always # I re-push it there sometimes
+  deployment:
+    strategy: 
+      type: Recreate # stop old pod before creating a new one
 
 hegel:
   image: quay.io/tinkerbell/hegel:v0.12.0

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -1,0 +1,79 @@
+# -- Overrides
+# The values defined here override those in the individual charts. Some of them require tweaking
+# before deployment as they are environment dependent; others are surfaced for convenience.
+#
+# See individual chart documentation for additional detail.
+
+# 67 - smee dhcp, hostNetwork; NodePort? (my guess is this requires hostNetwork, NodePort (kube-proxy) won't suffice
+# 69 - smee tftp, hostNetwork; NodePort? NodePort might or not suffice, no idea.
+# 514 - smee syslog, hostNetwork; NodePort
+# 7171 - smee http, should be directly exposed via hostNetwork (used for dhcp) anyway, but could be via NodePort or ingress too
+# 50061 - hegel http. either NodePort or ingress
+# 42113 - tink grpc. Either NodePort or ingress (special grpc_pass)
+
+# Scenarios to test:
+# simple bare k3s on bare vm (hostNetwork for everything, but maybe a few NodePorts needed for grpc and hegel)
+# k3s clustered 2+ nodes: NodePorts for everything, can run a replica of everything on each node, only one dhcp will ever be used
+
+hookImageServer:
+  enabled: true
+
+nodePort:
+  hookImageServer:
+    enabled: true
+    port: 32083
+  hegel: # @TODO this nodeport template
+    enabled: true
+    port: 32061
+  tinkGRPC:
+    enabled: true
+    port: 32013
+
+showcase:
+  enabled: true
+  hardware:
+    devices:
+      run-qemu-x86:
+        enabled: true
+      mekotronics-r58x-pro-via-usb: 
+        enabled: true
+  
+  
+  tinkerbell:
+    hostDirectory: "/opt/hook-jolly-roger" # This will be needed in smee one day as well, to serve DTB files over TFTP for u-boot
+    # These two should point to hookImageServer
+    hookURL: "http://192.168.99.2:32083"
+    imagesURL: "http://192.168.99.2:32083"
+    # points to smee at :514
+    syslogHost: "192.168.99.2"
+    # tink's grpc nodeport
+    grpcAuthority: "192.168.99.2:32013"
+    # @TODO one day use hegel to serve user-data and meta-data to _deployed cloud-init images_
+
+smee:
+  hostNetwork: true # no proxies, loadbalancers, or anything: it just runs as if directly on the k8s host.
+  logLevel: "debug"
+  tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.10.0
+  image: quay.io/tinkerbellrpardini/smee:latest-rpardini # custom build with updated ipxedust and arm64 NAPNULL for u-boot's PXE-via-EFI
+  # @TODO bug in smee chart, the values is under http: but the usage is not
+  trustedProxies: [ "0.0.0.0/0" ] # Trust _all_ proxies, insecure
+  publicIP: 192.168.99.2 # Must be set
+  imagePullPolicy: Always # I re-push it there sometimes
+
+hegel:
+  image: quay.io/tinkerbell/hegel:v0.12.0
+  trustedProxies: [ "0.0.0.0/0" ] # Trust _all_ proxies, insecure
+  nodePort:
+    enabled: true
+    port: 50061
+
+rufio:
+  image: quay.io/tinkerbell/rufio:v0.3.3
+
+tink:
+  controller:
+    image: quay.io/tinkerbell/tink-controller:latest # make sure we work with latest version
+    imagePullPolicy: Always
+  server:
+    image: quay.io/tinkerbell/tink:latest # to make sure we work with the la
+    imagePullPolicy: Always

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -32,11 +32,115 @@ nodePort:
 showcase:
   enabled: true
   hardware:
+    common:
+      uefi: true
+      ipv4:
+        # @TODO: Use _your_ values here! Also in the ipv4.address of the devices!
+        gateway: "192.168.99.1" # Must be set, otherwise no internet access; can be overriden per-device
+        netmask: "255.255.255.0"
+        dns: [ "192.168.66.1" ]
+
     devices:
-      run-qemu-x86:
-        enabled: true
-      mekotronics-r58x-pro-via-usb: 
-        enabled: true
+      ####  Examples for use in Hook development environment.
+      ####  There is a `bash build.sh build-run-qemu` command in Hook, that paired with
+      ####  `export MAC=11:22:33:44:55:66 TINK_SERVER=x.y.z.y` can be used with the below "machines".
+      ####  The MAC address is not really used by the qemu VM, but is passed via kernel cmdline.
+      "run-qemu-x86":
+        enabled: false
+        mac: "11:22:33:44:55:66"
+      "run-qemu-arm64":
+        enabled: false
+        mac: "11:22:33:44:55:77"
+      
+      
+      ### Examples for virtual machines, ran outside of Hook's build system.
+      ### Most virtualization software has support for PXE booting.
+      ### You will need to have (bridging/etc) setup to get a proper IP address from a real Smee, etc.
+      "vm03":
+        enabled: false
+        arch: aarch64
+        mac: "52:54:00:01:03:03"
+        rootDisk: "/dev/vdb"
+        ipv4:
+          address: "192.168.99.41"
+        hookRef: "armbian-uefi-arm64-edge" # "default-hook-aarch64" # defined above
+        imageRef: "ubuntu-jammy-cloud-arm64" # defined above
+        extraKernelCommandLine: "console=ttyAMA0"
+      
+      "vm09":
+        enabled: false
+        arch: x86_64
+        mac: "52:54:00:01:03:09"
+        rootDisk: "/dev/vdb"
+        ipv4:
+          address: "192.168.99.42"
+        hookRef: "armbian-uefi-x86-edge" # "default-hook-amd64" # defined above
+        imageRef: "ubuntu-jammy-cloud-amd64" # defined above
+        extraKernelCommandLine: "console=ttyS0"
+      
+      
+      ###
+      ### Examples for actual bare-metal hardware, mostly arm64 SBCs.
+      ###
+      
+      # Khadas VIM3L and other meson64-based boards (u-boot)
+      "vim3l":
+        enabled: false
+        arch: aarch64
+        mac: "c8:63:14:71:2a:6d"
+        rootDisk: "/dev/mmcblk0"
+        ipv4:
+          address: "192.168.99.51"
+        hookRef: "armbian-meson64-edge"
+        imageRef: "ubuntu-jammy-cloud-arm64"
+        extraKernelCommandLine: "console=ttyAML0,115200"
+      
+      # RockPro64 and other rockchip64-based boards (u-boot)
+      "rockpro64":
+        enabled: false
+        arch: aarch64
+        mac: "2a:36:cb:a2:ae:b8"
+        #rootDisk: "/dev/mmcblk2"  # mmcblk2 is the eMMC, mmcblk1 is the SD card
+        rootDisk: "/dev/disk/by-id/mmc-AJTD4R_0x0b05e84d" # much safer to use this style
+        ipv4:
+          address: "192.168.99.52"
+        hookRef: "armbian-rockchip64-edge" # defined above
+        imageRef: "armbian-rpardini-rockpro64-edge-uboot" # defined above
+        extraKernelCommandLine: "console=ttyS2,1500000"
+      
+      "orangepi3b":
+        enabled: false
+        arch: aarch64
+        mac: "b6:a7:96:d5:f1:84"
+        rootDisk: "/dev/disk/by-id/mmc-A3A551_0x2f8c5bd0" # /dev/mmcblk0 is the eMMC
+        ipv4:
+          address: "192.168.99.53"
+        hookRef: "armbian-rockchip64-edge"
+        imageRef: "armbian-rpardini-orangepi3b-edge-uboot" # defined above
+        extraKernelCommandLine: "console=ttyS2,1500000"
+      
+      # Raspberry Pi 4B (bcm2711), using edk2 UEFI firmware on an SD card, and an external NVMe-USB disk
+      "rpi4b":
+        enabled: false
+        arch: aarch64
+        mac: "dc:a6:32:ec:8b:49"
+        rootDisk: "/dev/disk/by-id/wwn-0x3001237923792379"
+        ipv4:
+          address: "192.168.99.54"
+        hookRef: "armbian-bcm2711-current" # works, as long as UEFI is set with ACPI+DTB and no 3gb limit. Use edk2 from https://github.com/pftf/RPi4
+        imageRef: "armbian-rpardini-rpi4b-current-not-efi" # defined above
+        extraKernelCommandLine: "console=tty1 console=ttyAMA0,115200 loglevel=7" # Last console defined "wins", thus use tty1 last if no serial console
+      
+      "mekotronics-r58x-pro-via-usb":
+        enabled: false
+        arch: aarch64
+        mac: "3c:18:a0:15:9a:9f" # 3C18A0159A9F
+        ipv4:
+          address: "192.168.99.55"
+        hookRef: "armbian-rk35xx-legacy" # "armbian-rk35xx-vendor"
+        imageRef: "armbian-rpardini-r58x-vendor-uboot"
+        extraKernelCommandLine: "console=ttyFIQ0:1500000 " # console=tty1  # Last console defined "wins", thus use tty1 last if no serial console
+        rootDisk: "/dev/nvme0NOENOENOENEyet"
   
   
   tinkerbell:

--- a/tinkerbell/suite/values.yaml
+++ b/tinkerbell/suite/values.yaml
@@ -56,27 +56,83 @@ showcase:
       ### Examples for virtual machines, ran outside of Hook's build system.
       ### Most virtualization software has support for PXE booting.
       ### You will need to have (bridging/etc) setup to get a proper IP address from a real Smee, etc.
-      "vm03":
+      "vm03": # For Armbian kernel Hook, and Ubuntu cloud image
         enabled: false
         arch: aarch64
         mac: "52:54:00:01:03:03"
         rootDisk: "/dev/vdb"
         ipv4:
           address: "192.168.99.41"
-        hookRef: "armbian-uefi-arm64-edge" # "default-hook-aarch64" # defined above
-        imageRef: "ubuntu-jammy-cloud-arm64" # defined above
-        extraKernelCommandLine: "console=ttyAMA0"
       
-      "vm09":
+      "vm04": # For default arm64 kernel Hook, and Ubuntu cloud image
         enabled: false
-        arch: x86_64
-        mac: "52:54:00:01:03:09"
+        arch: aarch64
+        mac: "52:54:00:01:03:04"
         rootDisk: "/dev/vdb"
         ipv4:
-          address: "192.168.99.42"
-        hookRef: "armbian-uefi-x86-edge" # "default-hook-amd64" # defined above
-        imageRef: "ubuntu-jammy-cloud-amd64" # defined above
+          address: "192.168.99.41"
+
+      "vm08":
+        enabled: true
+        arch: x86_64
+        mac: "52:54:00:01:03:08"
+        rootDisk: "/dev/disk/by-id/virtio-root_disk_serial"
+        ipv4:
+          address: "192.168.99.59"
         extraKernelCommandLine: "console=ttyS0"
+        imageRef: "fatso-ubuntu-noble-local-amd64"
+        #imageRef: "fatso-ubuntu-noble-baremetal-amd64"
+        hookRef: "default-hook-amd64"
+        userData: |
+          #include https://cloud-init.pardini.net/rpardini/oldskool-rpardini/master/base
+        #hookOverride:
+        #  bootMode: kexec
+
+      "vm09":
+        enabled: true
+        arch: x86_64
+        mac: "52:54:00:01:03:09"
+        rootDisk: "/dev/disk/by-id/virtio-root_disk_serial"
+        ipv4:
+          address: "192.168.99.61"
+        extraKernelCommandLine: "console=ttyS0"
+        imageRef: "fatso-ubuntu-noble-baremetal-amd64" # "fatso-ubuntu-noble-local-amd64"
+        hookRef: "default-hook-amd64"
+        #hookOverride:
+        #  bootMode: kexec
+      
+      
+      "thundercat":
+        enabled: true
+        arch: x86_64
+        #mac: "3c:18:a0:15:9a:9f" # thinkpad 100mbit/s?
+        #mac: "8c:ae:4c:dd:10:78" # 2.5gbit plugable
+        mac: "3c:18:a0:95:69:f7" # amazonbasics white usb3
+        rootDisk: "/dev/sda"
+        ipv4:
+          address: "192.168.99.70"
+        #extraKernelCommandLine: "console=ttyUSB0,115200" 
+        #extraKernelCommandLine: "console=tty0 "
+        extraKernelCommandLine: "console=tty0 " # console=ttyUSB0,115200 # n8 breaks getty?
+        #hookOverride:
+        #  bootMode: kexec
+        userData: |
+          #include https://cloud-init.pardini.net/rpardini/oldskool-rpardini/master/base
+
+        #hookRef: "latest-lts-amd64"
+        hookRef: "default-hook-amd64"
+        #hookRef: "armbian-uefi-x86-edge" # "default-hook-amd64" # defined above
+        #hookRef: "peg-default-amd64" # "default-hook-amd64" # defined above
+        #hookRef: "pegk-default-amd64" # "default-hook-amd64" # defined above
+        #hookRef: "dev-pegk-default-amd64" # "default-hook-amd64" # defined above
+        #hookRef: "dev-default-hook-amd64" # "default-hook-amd64" # defined above
+
+        #imageRef: "fatso-el9-local-amd64"
+        imageRef: "fatso-ubuntu-noble-local-amd64"
+        #imageRef: "fatso-rocky8-baremetal-amd64"
+        #imageRef: "fatso-rocky8-local-amd64"
+        #imageRef: "fatso-ubuntu-noble-baremetal-amd64"
+        #imageRef: "fatso-ubuntu-noble-local-amd64"
       
       
       ###
@@ -86,61 +142,41 @@ showcase:
       # Khadas VIM3L and other meson64-based boards (u-boot)
       "vim3l":
         enabled: false
-        arch: aarch64
         mac: "c8:63:14:71:2a:6d"
         rootDisk: "/dev/mmcblk0"
         ipv4:
           address: "192.168.99.51"
-        hookRef: "armbian-meson64-edge"
-        imageRef: "ubuntu-jammy-cloud-arm64"
-        extraKernelCommandLine: "console=ttyAML0,115200"
       
       # RockPro64 and other rockchip64-based boards (u-boot)
       "rockpro64":
         enabled: false
-        arch: aarch64
         mac: "2a:36:cb:a2:ae:b8"
         #rootDisk: "/dev/mmcblk2"  # mmcblk2 is the eMMC, mmcblk1 is the SD card
         rootDisk: "/dev/disk/by-id/mmc-AJTD4R_0x0b05e84d" # much safer to use this style
         ipv4:
           address: "192.168.99.52"
-        hookRef: "armbian-rockchip64-edge" # defined above
-        imageRef: "armbian-rpardini-rockpro64-edge-uboot" # defined above
-        extraKernelCommandLine: "console=ttyS2,1500000"
       
       "orangepi3b":
         enabled: false
-        arch: aarch64
         mac: "b6:a7:96:d5:f1:84"
-        rootDisk: "/dev/disk/by-id/mmc-A3A551_0x2f8c5bd0" # /dev/mmcblk0 is the eMMC
+        rootDisk: "/dev/disk/by-id/wwn-0x3001237923792379" # /dev/mmcblk0 is the eMMC
         ipv4:
           address: "192.168.99.53"
-        hookRef: "armbian-rockchip64-edge"
-        imageRef: "armbian-rpardini-orangepi3b-edge-uboot" # defined above
-        extraKernelCommandLine: "console=ttyS2,1500000"
       
       # Raspberry Pi 4B (bcm2711), using edk2 UEFI firmware on an SD card, and an external NVMe-USB disk
       "rpi4b":
         enabled: false
-        arch: aarch64
         mac: "dc:a6:32:ec:8b:49"
         rootDisk: "/dev/disk/by-id/wwn-0x3001237923792379"
         ipv4:
           address: "192.168.99.54"
-        hookRef: "armbian-bcm2711-current" # works, as long as UEFI is set with ACPI+DTB and no 3gb limit. Use edk2 from https://github.com/pftf/RPi4
-        imageRef: "armbian-rpardini-rpi4b-current-not-efi" # defined above
-        extraKernelCommandLine: "console=tty1 console=ttyAMA0,115200 loglevel=7" # Last console defined "wins", thus use tty1 last if no serial console
       
       "mekotronics-r58x-pro-via-usb":
         enabled: false
-        arch: aarch64
         mac: "3c:18:a0:15:9a:9f" # 3C18A0159A9F
         ipv4:
           address: "192.168.99.55"
-        hookRef: "armbian-rk35xx-legacy" # "armbian-rk35xx-vendor"
-        imageRef: "armbian-rpardini-r58x-vendor-uboot"
-        extraKernelCommandLine: "console=ttyFIQ0:1500000 " # console=tty1  # Last console defined "wins", thus use tty1 last if no serial console
-        rootDisk: "/dev/nvme0NOENOENOENEyet"
+        rootDisk: "/dev/disk/by-id/nvme-WD_Blue_SN570_1TB_231421807346" # Gooo!
   
   
   tinkerbell:
@@ -159,13 +195,13 @@ smee:
   hostNetwork: true # no proxies, loadbalancers, or anything: it just runs as if directly on the k8s host.
   logLevel: "debug"
   tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.10.0
-  image: quay.io/tinkerbellrpardini/smee:latest-rpardini # custom build with updated ipxedust and arm64 NAPNULL for u-boot's PXE-via-EFI
+  image: quay.io/tinkerbellrpardini/smee:latest-rpardini4 # custom build with updated ipxedust and arm64 NAPNULL for u-boot's PXE-via-EFI
   # @TODO bug in smee chart, the values is under http: but the usage is not
   trustedProxies: [ "0.0.0.0/0" ] # Trust _all_ proxies, insecure
   publicIP: 192.168.99.2 # Must be set
   imagePullPolicy: Always # I re-push it there sometimes
   deployment:
-    strategy: 
+    strategy:
       type: Recreate # stop old pod before creating a new one
 
 hegel:


### PR DESCRIPTION
#### tinkerbell/charts: introduce `showcase` chart

- `showcase` is a chart that, based on values.yaml dictionaries:
    - generates Tinkerbell CRs (Hardware/Template/Workflow) for both standard (UEFI) & exotic (supported by Armbian) devices
    - generates download/process jobs for multiple Hook flavors (see https://github.com/tinkerbell/hook/pull/205)
    - generates download/process jobs for a few OS images (Ubuntu Cloud Images, Armbian, etc)
    - should be independent of how one deployed Tinkerbell itself (stack chart, individual components, etc)
- A few features:
    - validates values.yaml for common mistakes; arch must match, etc.
    - validates & handles rootDisk differences (re-invents "formatPartition()" a bit)
    - avoids re-downloading Hooks and Images that are already on disk, even if Job re-runs
    - allows easy way to use
        - custom Hooks
        - custom Kernel cmdline parameters at both the Hook & device level
            - for example `acpi=off` at Hook level and `console=ttyS0` at board level
        - custom OS images for deployment
        - reboot or kexec to finish deployment
        - different partition numbers for OS image's rootfs (some images have ESP, some have a separate `/boot`, etc)
        - control if growpart and/or ssh/user setup is done during provisioning or not
        - conversion of OS images (`qemu-to-raw-gzip` and `xz-to-gz`)
    - has a "merge" mechanism with a common way to set parameters like net gateway, UEFI, etc (also easy to override per-device)
    - default values have everything `enabled: false` thus showcase should produce nothing by default.
        - Hooks & Images can be forced `enabled: true` in values.yaml, or
            - `enabled: true` Devices automatically enable their Hook & Image
- Probably missing:
    - More validations
    - Currently pointing to my Tinkerbell Actions, which I haven't PR'ed yet
- How to use:
    - Clone it, edit the values.yaml to your liking, and deploy.

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>