### PR TITLE
Workaround for ipvlan interfaces:

### DIFF
--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -143,8 +143,16 @@ spec:
             # Set the interface up
             ip link set {{ $dhcpInterfaceName }} up
             # Set the IP address
-            ip addr add 127.1.1.1/32 dev {{ $dhcpInterfaceName }} noprefixroute
-        image: alpine
+            ip addr add 127.1.1.1/32 dev {{ $dhcpInterfaceName }} noprefixroute || true
+            {{- if eq $dhcpInterfaceType "ipvlan" }}
+            # There is an issue with ipvlan interfaces. They do not start receiving broadcast packets after creation.
+            # This is a workaround to get broadcast packets flowing.
+            # TODO(jacobweinstock): Investigate this deeper and see if this is a kernel bug.
+            nsenter -t1 -n ip link del {{ $dhcpInterfaceName }}-wa || true
+            nsenter -t1 -n nmap --script broadcast-dhcp-discover
+            nsenter -t1 -n ip link add {{ $dhcpInterfaceName }}-wa link ${srcInterface} type ipvlan mode l2 bridge || true
+            {{- end }}
+        image: ghcr.io/jacobweinstock/relay-init:v0.1.0
         securityContext:
           privileged: true
       {{- end }}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
There is an issue with ipvlan interfaces not receiving packets after creation. This works around this issue to get packets flowing. This should be investigated deeper to understand why this is happening.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
