### PR TITLE
Handle shasum checking for HookOS > 0.8.1:

### DIFF
--- a/tinkerbell/stack/templates/hook.yaml
+++ b/tinkerbell/stack/templates/hook.yaml
@@ -19,7 +19,9 @@ data:
       echo "${f}"
       wget -P "${tmp_dir}" "${f}"
     done
-    (cd "${tmp_dir}" && sha512sum -c checksum.txt)
+    # releases of HookOS > 0.8.1 provide more binaries.
+    # We only need the hook_aarch64 and hook_x86_64 binaries so we filter out the rest.
+    (cd "${tmp_dir}" && sed -i '/hook_x86_64\|hook_aarch64/!d' checksum.txt && sha512sum -c checksum.txt)
     mv "${tmp_dir}"/checksum.txt .
     for f in ${tmp_dir}/*.tar.gz; do tar --no-same-permissions --overwrite -ozxvf "${f}" && rm -f "${f}"; done
     rm -rf "${tmp_dir}"


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Releases of HookOS > 0.8.1 provide more binaries. We only need the hook_aarch64 and hook_x86_64 binaries so we filter out the rest.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
