### PR TITLE
Make dhcp-relay init container configurable:

### DIFF
--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -152,7 +152,7 @@ spec:
             nsenter -t1 -n nmap --script broadcast-dhcp-discover
             nsenter -t1 -n ip link add {{ $dhcpInterfaceName }}-wa link ${srcInterface} type ipvlan mode l2 bridge || true
             {{- end }}
-        image: ghcr.io/jacobweinstock/relay-init:v0.1.0
+        image: {{ .Values.stack.relay.initImage }}
         securityContext:
           privileged: true
       {{- end }}

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -39,6 +39,8 @@ stack:
     # This image (ghcr.io/jacobweinstock/dhcrelay) is used because the other public dhcprelay images out there (`modem7/dhcprelay`)
     # don't respect signals properly when run as PID 1.
     image: ghcr.io/jacobweinstock/dhcprelay # dhcprelay is a multiarch-enabled version of dhcrelay
+    # if `interfaceMode: ipvlan`, then ghcr.io/jacobweinstock/relay-init:v0.1.0 (has nmap and nmap-scripts) is required. Otherwise, alpine can be used. 
+    initImage: ghcr.io/jacobweinstock/relay-init:v0.1.0
     maxHopCount: 10
     # The presentGiaddrAction pertains to the course of action when the giaddr field appears in the DHCP packet.
     # In situations where another DHCP relay agent is already in operation within the environment,


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
When `interfaceMode: ipvlan` is not set the existing container image might not be desireable.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
