### PR TITLE
Add clusterctl labels to crds

### DIFF
--- a/tinkerbell/rufio/crds/bmc.tinkerbell.org_machines.yaml
+++ b/tinkerbell/rufio/crds/bmc.tinkerbell.org_machines.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
   name: machines.bmc.tinkerbell.org
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""
 spec:
   group: bmc.tinkerbell.org
   names:

--- a/tinkerbell/tink/crds/hardware-crd.yaml
+++ b/tinkerbell/tink/crds/hardware-crd.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   name: hardware.tinkerbell.org
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""
 spec:
   group: tinkerbell.org
   names:

--- a/tinkerbell/tink/crds/template-crd.yaml
+++ b/tinkerbell/tink/crds/template-crd.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.4
   name: templates.tinkerbell.org
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""
 spec:
   group: tinkerbell.org
   names:


### PR DESCRIPTION
## Description
Adds `clusterctl` and `clusterctl/move` labels to rufio bmc machine CRDs and tink hardware and template CRDs.

## Why is this needed
This allows the machine CRs to be moved during a `clusterctl move` command. 

## How Has This Been Tested?
Tested with EKS-Anywhere to confirm that crds are not left behind when performing `clusterctl move`



