### PR TITLE
Nodeselector

### DIFF
--- a/tinkerbell/hegel/Chart.yaml
+++ b/tinkerbell/hegel/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/hegel/templates/deployment.yaml
+++ b/tinkerbell/hegel/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
           - --backend=kubernetes

--- a/tinkerbell/hegel/values.yaml
+++ b/tinkerbell/hegel/values.yaml
@@ -17,6 +17,7 @@ resources:
     memory: 64Mi
 roleName: hegel-role
 roleBindingName: hegel-rolebinding
+nodeSelector: {}
 
 # Trusted proxies defines a list of IP or CIDR ranges that are allowed to set the X-Forwarded-For
 # header. This typically requires all Pod CIDRs in the cluster.

--- a/tinkerbell/rufio/Chart.yaml
+++ b/tinkerbell/rufio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/rufio/templates/deployment.yaml
+++ b/tinkerbell/rufio/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         control-plane: controller-manager
         stack: tinkerbell
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
       containers:

--- a/tinkerbell/rufio/templates/deployment.yaml
+++ b/tinkerbell/rufio/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         control-plane: controller-manager
         stack: tinkerbell
     spec:
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: 
         {{- toYaml . | nindent 8 }}

--- a/tinkerbell/rufio/templates/deployment.yaml
+++ b/tinkerbell/rufio/templates/deployment.yaml
@@ -23,10 +23,6 @@ spec:
         control-plane: controller-manager
         stack: tinkerbell
     spec:
-      {{- if .Values.hostNetwork }}
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: 
         {{- toYaml . | nindent 8 }}

--- a/tinkerbell/rufio/values.yaml
+++ b/tinkerbell/rufio/values.yaml
@@ -15,3 +15,4 @@ managerRoleName: rufio-manager-role
 rufioLeaderElectionRoleBindingName: rufio-leader-election-rolebinding
 managerRoleBindingName: rufio-manager-rolebinding
 nodeSelector: {}
+hostNetwork: false

--- a/tinkerbell/rufio/values.yaml
+++ b/tinkerbell/rufio/values.yaml
@@ -15,4 +15,3 @@ managerRoleName: rufio-manager-role
 rufioLeaderElectionRoleBindingName: rufio-leader-election-rolebinding
 managerRoleBindingName: rufio-manager-rolebinding
 nodeSelector: {}
-hostNetwork: false

--- a/tinkerbell/rufio/values.yaml
+++ b/tinkerbell/rufio/values.yaml
@@ -14,3 +14,4 @@ rufioLeaderElectionRoleName: rufio-leader-election-role
 managerRoleName: rufio-manager-role
 rufioLeaderElectionRoleBindingName: rufio-leader-election-rolebinding
 managerRoleBindingName: rufio-manager-rolebinding
+nodeSelector: {}

--- a/tinkerbell/smee/Chart.yaml
+++ b/tinkerbell/smee/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/smee/templates/deployment.yaml
+++ b/tinkerbell/smee/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/tinkerbell/smee/values.yaml
+++ b/tinkerbell/smee/values.yaml
@@ -34,6 +34,9 @@ logLevel: "info"
 # host network.
 hostNetwork: false
 
+# nodeSelector when defined will be constrain Pods to nodes with specific labels
+nodeSelector: {}
+
 # publicIP when defined will be used as the IP in the following locations if they are not defined:
 # dhcp.httpIPXE.binaryUrl.host, dhcp.httpIPXE.scriptUrl.host, tinkServer.ip, http.osieUrl.host, dhcp.ipForPacket, dhcp.tftpIp
 # This is useful when all Tinkerbell services are running behind the same IP.

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: tink
   repository: file://../tink
-  version: 0.2.3
+  version: 0.2.4
 - name: smee
   repository: file://../smee
-  version: 0.3.3
+  version: 0.3.4
 - name: rufio
   repository: file://../rufio
-  version: 0.2.8
+  version: 0.2.9
 - name: hegel
   repository: file://../hegel
-  version: 0.3.4
-digest: sha256:3c3ee0743e457ff4990ab5d6546deba0d53658a148085989f5e6a85f15251284
-generated: "2024-04-23T18:03:55.743243719-06:00"
+  version: 0.3.5
+digest: sha256:8adf6b3a5dea3c6a5ccb1cd5a32619a6fa9f79d0ac23d8601b95687dd63aac59
+generated: "2024-06-04T15:48:10.744939275-06:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -15,24 +15,24 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.4"
+appVersion: "0.4.5"
 
 dependencies:
   - name: tink
-    version: "0.2.3"
+    version: "0.2.4"
     repository: "file://../tink"
   - name: smee
-    version: "0.3.3"
+    version: "0.3.4"
     repository: "file://../smee"
   - name: rufio
-    version: "0.2.8"
+    version: "0.2.9"
     repository: "file://../rufio"
   - name: hegel
-    version: "0.3.4"
+    version: "0.3.5"
     repository: "file://../hegel"

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -6,6 +6,7 @@ stack:
     type: LoadBalancer
   selector:
     app: tink-stack
+  nodeSelector: {}
   # stack needs to resolve DNS names in the cluster (in .svc.clusterDomain)
   clusterDomain: cluster.local
   # &publicIP is a YAML anchor. It allows us to define a value once and reference it multiple times.

--- a/tinkerbell/tink/Chart.yaml
+++ b/tinkerbell/tink/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/tink/templates/tink-controller/deployment.yaml
+++ b/tinkerbell/tink/templates/tink-controller/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app: {{ .Values.controller.name }}
     spec:
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - image: {{ .Values.controller.image }}
           imagePullPolicy: {{ .Values.controller.imagePullPolicy }}

--- a/tinkerbell/tink/templates/tink-server/deployment.yaml
+++ b/tinkerbell/tink/templates/tink-server/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - --backend=kubernetes

--- a/tinkerbell/tink/values.yaml
+++ b/tinkerbell/tink/values.yaml
@@ -16,6 +16,7 @@ controller:
   roleBindingName: tink-controller-manager-rolebinding
   tinkLeaderElectionRoleName: tink-leader-election-role
   tinkLeaderElectionRoleBindingName: tink-leader-election-rolebinding
+  nodeSelector: {}
 
 server:
   deploy: true
@@ -37,3 +38,4 @@ server:
       memory: 64Mi
   roleName: tink-server-role
   roleBindingName: tink-server-rolebinding
+  nodeSelector: {}


### PR DESCRIPTION
## Description

## Why is this needed
We have a larger kubernetes cluster running and need to be able to control which node the tinkerbell pods run on. The easiest way for us is to control the pods via a node label and nodeSelector

## How Has This Been Tested?
We have installed a 3 node RKE2 cluster and the nodes on which the Tinkerbell pods are to run with
`node-role.kubernetes.io/tinkerbell: 'true'`.
With the helm value
```
nodeSelector:
  node-role.kubernetes.io/tinkerbell: 'true'
```
We then deployed the Tinkerbell stack and checked which nodes the pods were running on.