### PR TITLE
Tinkerbell chart improvements

### DIFF
--- a/tinkerbell/rufio/templates/deployment.yaml
+++ b/tinkerbell/rufio/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        {{- range .Values.additionalArgs }}
+        - {{ . }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/tinkerbell/rufio/values.yaml
+++ b/tinkerbell/rufio/values.yaml
@@ -9,6 +9,7 @@ resources:
   limits:
     cpu: 500m
     memory: 128Mi
+additionalArgs: []
 serviceAccountName: rufio-controller-manager
 rufioLeaderElectionRoleName: rufio-leader-election-role
 managerRoleName: rufio-manager-role

--- a/tinkerbell/smee/templates/_ports.tpl
+++ b/tinkerbell/smee/templates/_ports.tpl
@@ -14,7 +14,11 @@
 {{- end }}
 
 {{- define "urlJoiner" }}
+{{- if .urlDict.port }}
 {{- $host := printf "%v:%v" .urlDict.host .urlDict.port }}
 {{- $newDict := set .urlDict "host" $host }}
 {{- print (urlJoin $newDict) }}
+{{- else }}
+{{- print (urlJoin .urlDict) }}
+{{- end }}
 {{- end }}

--- a/tinkerbell/stack/templates/kubevip.yaml
+++ b/tinkerbell/stack/templates/kubevip.yaml
@@ -27,6 +27,10 @@ spec:
           value: "true"
         - name: enableServicesElection
           value: "true"
+        {{- range .Values.stack.kubevip.additionalEnv }}
+        - name: {{ .name | quote }}
+          value: {{ .value | quote }}
+        {{- end }}
         {{- with .Values.stack.kubevip.interface }}
         - name: vip_interface
           value: {{ . }}

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -33,6 +33,15 @@ stack:
     roleBindingName: kube-vip-rolebinding
     # Customize the interface KubeVIP advertises on. When unset, KubeVIP will autodetect the interface.
     # interface: enp0s8
+
+    # Additional environment variables to pass to the kubevip container. Each entry is expected to have a
+    # name and value key. Some keys are already defined - refer to the deployment.yaml template for
+    # details.
+    #
+    # Example
+    #   - name: MY_ENV_VAR
+    #     value: my-value
+    additionalEnv: []
   # Relay allows us to listen and respond to layer broadcast DHCP requests
   relay:
     name: dhcp-relay


### PR DESCRIPTION
## Description
This PR adds the following:
- Templates out the args for the rufio deployment so that users can provide other rufio flags if desired.
- Updates "urlJoiner" to not add a colon to the url if no port is provided
- Allows kubevip `prometheus_server` to be set to override the default address

## Why is this needed
These changes allow the tinkerbell chart to be more customizable for various use cases

## How Has This Been Tested?
Tested manually with EKS-Anywhere

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
