### PR TITLE
Remove nginx Smee services when Smee's in hostNetwork mode:

### DIFF
--- a/tinkerbell/stack/templates/nginx-configmap.yaml
+++ b/tinkerbell/stack/templates/nginx-configmap.yaml
@@ -15,6 +15,7 @@ data:
     user root;
 
     http {
+      {{- if not .Values.smee.hostNetwork }}
       server {
         listen {{ .Values.smee.http.port }};
         location / {
@@ -26,6 +27,7 @@ data:
           proxy_pass http://$smee_dns:{{ .Values.smee.http.port }};
         }
       }
+      {{- end }}
 
       server {
         listen {{ .Values.hegel.service.port }};
@@ -65,6 +67,7 @@ data:
     stream {
       log_format logger-json escape=json '{"source": "nginx", "time": $msec, "address": "$remote_addr", "status": $status, "upstream_addr": "$upstream_addr"}';
 
+      {{- if not .Values.smee.hostNetwork }}
       server {
           listen {{ .Values.smee.tftp.port }} udp;
           resolver $POD_NAMESERVER;
@@ -79,5 +82,6 @@ data:
           proxy_pass $smee_dns:{{ .Values.smee.syslog.port }};
           access_log /dev/stdout logger-json;
       }
+      {{- end }}
     }
 {{- end }}

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -60,6 +60,7 @@ spec:
         - containerPort: {{ .Values.stack.hook.port }}
           protocol: TCP
           name: hook-http
+        {{- if not .Values.smee.hostNetwork }}
         - containerPort: {{ .Values.smee.http.port }}
           protocol: TCP
           name: {{ .Values.smee.http.name }}
@@ -69,6 +70,7 @@ spec:
         - containerPort: {{ .Values.smee.syslog.port }}
           protocol: UDP
           name: {{ .Values.smee.syslog.name }}
+        {{- end }}
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This removes issues when both Smee and nginx want to listen on the same ports.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
