### PR TITLE
Revert "Remove list permission on secrets for Rufio:"

### DIFF
--- a/tinkerbell/rufio/templates/cluster-role.yaml
+++ b/tinkerbell/rufio/templates/cluster-role.yaml
@@ -11,6 +11,7 @@ rules:
   - secrets
   verbs:
   - get
+  - list
   - watch
 - apiGroups:
   - bmc.tinkerbell.org


### PR DESCRIPTION
Reverts tinkerbell/charts#102

Rufio uses controller-runtime. Controller-runtime needs list permissions for its caching mechanism.
_"// Cache is the cache.Options that will be used to create the default Cache.
// By default, the cache will watch and list requested objects in all namespaces."_ -  https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#Options

https://github.com/kubernetes-sigs/controller-runtime/issues/1220
