### PR TITLE
fix container for ipv6

### DIFF
--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -48,8 +48,9 @@ spec:
         command: ["/bin/bash", "-xeuc"]
         args:
         - |
-          POD_NAMESERVER=$(awk '/nameserver/ {print $2}' /etc/resolv.conf) \
-            envsubst '$POD_NAMESERVER' \
+          export POD_NAMESERVER=$(awk '/nameserver/ {print $2}' /etc/resolv.conf);
+          [[ $POD_NAMESERVER == *.* ]] || POD_NAMESERVER="[$POD_NAMESERVER]";
+          envsubst '$POD_NAMESERVER' \
             </tmp/nginx.conf.template \
             >/etc/nginx/nginx.conf
           exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Description

the tink-stack pod crashes on an ipv6 only cluster because the container can not handle IPv6 addresses
```
:~# kubectl logs -n tink-system tink-stack-6bbc556dd-znd6j
Defaulted container "tink-stack" out of: tink-stack, dhcp-relay
++ awk '/nameserver/ {print $2}' /etc/resolv.conf
+ POD_NAMESERVER=fd05:0000:0000::a
+ envsubst '$POD_NAMESERVER'
+ exec nginx -g 'daemon off;'
2024/06/03 16:23:37 [emerg] 3210953#3210953: invalid port in resolver "fd05:0000:0000::a" in /etc/nginx/nginx.conf:13
nginx: [emerg] invalid port in resolver "fd05:0000:0000::a" in /etc/nginx/nginx.conf:13
```

## Why is this needed

We use an IPv6 only RKE2 Cluster and we need to start this container correctly.

Fixes: #99

## How Has This Been Tested?
I tested the fix in our RKE2 IPv6 only cluster and it works. But i don't have an IPv4 environment for testing
