### PR TITLE
add hostNetwork to rufio

### DIFF
--- a/tinkerbell/rufio/templates/deployment.yaml
+++ b/tinkerbell/rufio/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         control-plane: controller-manager
         stack: tinkerbell
     spec:
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: 
         {{- toYaml . | nindent 8 }}

--- a/tinkerbell/rufio/values.yaml
+++ b/tinkerbell/rufio/values.yaml
@@ -16,6 +16,7 @@ managerRoleName: rufio-manager-role
 rufioLeaderElectionRoleBindingName: rufio-leader-election-rolebinding
 managerRoleBindingName: rufio-manager-rolebinding
 nodeSelector: {}
+hostNetwork: false
 # singleNodeClusterConfig to add tolerations for deployments on control plane nodes. This is defaulted to false.
 singleNodeClusterConfig:
   controlPlaneTolerationsEnabled: false


### PR DESCRIPTION
We run an RKE2 IPv6 only cluster.
Three network cards are configured on the nodes (two with IPv6 and one with IPv4, which is only responsible for BMC traffic)
As CNI we use cilium with a very simple config (nothing is specially set here)
we have also not set any special egress or ingress rules.

If we now run rufio in the cluster network, we get no traffic to the BMC. In the logs there is a "not authenticated" error and using tcpdump I don't see any traffic.
If we now run rufio in the host network, I see traffic in the tcpdump and the node can also be restarted using rufio via the BMC.

We therefore need the option to set the host network here.

I already had an conversation with @jacobweinstock about this via Slack