### PR TITLE
Update Smee version

### DIFF
--- a/tinkerbell/smee/Chart.yaml
+++ b/tinkerbell/smee/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.0"
+appVersion: "0.12.0"

--- a/tinkerbell/smee/templates/deployment.yaml
+++ b/tinkerbell/smee/templates/deployment.yaml
@@ -45,25 +45,37 @@ spec:
             - -backend-kube-namespace={{ .Release.Namespace }}
             - -dhcp-addr={{ printf "%v:%v" .Values.dhcp.ip .Values.dhcp.port }}
             - -dhcp-enabled={{ .Values.dhcp.enabled }}
-            - -dhcp-http-ipxe-binary-url={{include "urlJoiner" (dict "urlDict" .Values.dhcp.httpIPXE.binaryUrl)}}
-            - -dhcp-http-ipxe-script-url={{include "urlJoiner" (dict "urlDict" .Values.dhcp.httpIPXE.scriptUrl)}}
-            - -dhcp-ip-for-packet={{ .Values.dhcp.ipForPacket }}
-            - -dhcp-syslog-ip={{ .Values.dhcp.syslogIp }}
-            - -dhcp-tftp-ip={{ .Values.dhcp.tftpIp }}:69
+            - -dhcp-tftp-port={{ .Values.dhcp.tftpPort }}
+            - -dhcp-http-ipxe-binary-path={{ .Values.dhcp.httpIPXE.binaryUrl.path }}
+            - -dhcp-http-ipxe-binary-port={{ .Values.dhcp.httpIPXE.binaryUrl.port }}
+            - -dhcp-http-ipxe-binary-scheme={{ .Values.dhcp.httpIPXE.binaryUrl.scheme }}
+            - -dhcp-http-ipxe-script-path={{ .Values.dhcp.httpIPXE.scriptUrl.path }}
+            - -dhcp-http-ipxe-script-port={{ .Values.dhcp.httpIPXE.scriptUrl.port }}
+            - -dhcp-http-ipxe-script-scheme={{ .Values.dhcp.httpIPXE.scriptUrl.scheme }}
             - -extra-kernel-args={{ join " " ( append .Values.http.additionalKernelArgs ( printf "tink_worker_image=%s" ( required "missing tinkWorkerImage" .Values.tinkWorkerImage ) ) ) }}
-            - -http-addr={{ printf "%v:%v" .Values.http.ip .Values.http.port }}
             - -http-ipxe-binary-enabled={{ .Values.http.ipxeBinaryEnabled }}
             - -http-ipxe-script-enabled={{ .Values.http.ipxeScriptEnabled }}
+            - -http-port={{ .Values.http.port }}
             - -osie-url={{include "urlJoiner" (dict "urlDict" .Values.http.osieUrl)}}
             - -tink-server={{ printf "%v:%v" .Values.http.tinkServer.ip .Values.http.tinkServer.port }}
             - -tink-server-tls={{ .Values.http.tinkServer.tls }}
             - -trusted-proxies={{ required "missing trustedProxies" ( join "," .Values.trustedProxies ) }}
-            - -syslog-addr={{ printf "%v:%v" .Values.syslog.ip .Values.syslog.port }}
             - -syslog-enabled={{ .Values.syslog.enabled }}
             - -ipxe-script-patch={{ .Values.ipxeScriptPatch }}
-            - -tftp-addr={{ printf "%v:%v" .Values.tftp.ip .Values.tftp.port }}
             - -tftp-enabled={{ .Values.tftp.enabled }}
             - -tftp-timeout={{ .Values.tftp.timeout }}
+            - -tftp-port={{ .Values.tftp.port }}
+            - -syslog-port={{ .Values.syslog.port }}
+            {{- if not .Values.hostNetwork }}
+            - -http-addr={{ .Values.http.ip }}
+            - -syslog-addr={{ .Values.syslog.ip }}
+            - -tftp-addr={{ .Values.tftp.ip }}
+            - -dhcp-http-ipxe-binary-host={{ .Values.dhcp.httpIPXE.binaryUrl.host}}
+            - -dhcp-http-ipxe-script-host={{ .Values.dhcp.httpIPXE.scriptUrl.host }}
+            - -dhcp-syslog-ip={{ .Values.dhcp.syslogIp }}
+            - -dhcp-tftp-ip={{ .Values.dhcp.tftpIp }}
+            - -dhcp-ip-for-packet={{ .Values.dhcp.ipForPacket }}
+            {{- end }}
           {{- range .Values.additionalArgs }}
             - {{ . }}
           {{- end }}

--- a/tinkerbell/smee/values.yaml
+++ b/tinkerbell/smee/values.yaml
@@ -51,6 +51,7 @@ dhcp:
   port: 67
   ipForPacket: ""
   tftpIp: ""
+  tftpPort: 69
   syslogIp: ""
   httpIPXE:
       binaryUrl: # http://<host>:<port>/ipxe

--- a/tinkerbell/smee/values.yaml
+++ b/tinkerbell/smee/values.yaml
@@ -5,7 +5,7 @@ deploy: true
 name: smee
 
 # The image used to launch the container.
-image: quay.io/tinkerbell/smee:v0.11.0
+image: quay.io/tinkerbell/smee:v0.12.0
 imagePullPolicy: IfNotPresent
 
 # The number of pods to run.

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.2.5
 - name: smee
   repository: file://../smee
-  version: 0.3.5
+  version: 0.4.0
 - name: rufio
   repository: file://../rufio
   version: 0.2.10
 - name: hegel
   repository: file://../hegel
   version: 0.3.6
-digest: sha256:5ddb03f83b97f945fafaff989c86da72691f388da0edc33cd85782392273c21b
-generated: "2024-06-10T16:59:58.906762-07:00"
+digest: sha256:ecc845c70a90e6adb0efb038db53e4685714494b676d5e24ce7ea1277097b4ff
+generated: "2024-07-09T15:13:10.080527749-06:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -15,20 +15,20 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.5"
+appVersion: "0.5.0"
 
 dependencies:
   - name: tink
     version: "0.2.5"
     repository: "file://../tink"
   - name: smee
-    version: "0.3.5"
+    version: "0.4.0"
     repository: "file://../smee"
   - name: rufio
     version: "0.2.10"

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -79,7 +79,7 @@ stack:
 # See individual chart documentation for additional detail.
 
 smee:
-  image: quay.io/tinkerbell/smee:v0.11.0
+  image: quay.io/tinkerbell/smee:v0.12.0
   tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.10.0
   trustedProxies: []
   publicIP: *publicIP


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

This version of Smee separates out ports from IPs in CLI flags. This allows us to properly do Smee `hostNetwork: true`. This is a breaking change in Smee as the flags aren't the same anymore.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
