### PR TITLE
smee: add http.tinkServer.insecureTLS controlling `-tink-server-insecure-tls`

### DIFF
--- a/tinkerbell/smee/templates/deployment.yaml
+++ b/tinkerbell/smee/templates/deployment.yaml
@@ -70,6 +70,7 @@ spec:
             - -osie-url={{include "urlJoiner" (dict "urlDict" .Values.http.osieUrl)}}
             - -tink-server={{ printf "%v:%v" .Values.http.tinkServer.ip .Values.http.tinkServer.port }}
             - -tink-server-tls={{ .Values.http.tinkServer.tls }}
+            - -tink-server-insecure-tls={{ .Values.http.tinkServer.insecureTLS }}
             - -trusted-proxies={{ required "missing trustedProxies" ( join "," $trustedProxies ) }}
             - -syslog-enabled={{ .Values.syslog.enabled }}
             - -ipxe-script-patch={{ .Values.ipxeScriptPatch }}

--- a/tinkerbell/smee/values.yaml
+++ b/tinkerbell/smee/values.yaml
@@ -87,6 +87,7 @@ http:
     ip: ""
     port: 42113
     tls: false
+    insecureTLS: false
   osieUrl:
     scheme: "http"
     host: ""


### PR DESCRIPTION
#### smee: add http.tinkServer.insecureTLS controlling `-tink-server-insecure-tls`

- this fits in with
  -  https://github.com/tinkerbell/smee/pull/479
  -  https://github.com/tinkerbell/tink/pull/960
  - https://github.com/tinkerbell/hook/pull/234

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>