### PR TITLE
Add lb_class_only env var to restrict ips for LB class only

### DIFF
--- a/tinkerbell/stack/templates/kubevip.yaml
+++ b/tinkerbell/stack/templates/kubevip.yaml
@@ -25,6 +25,8 @@ spec:
           value: "true"
         - name: svc_election
           value: "true"
+        - name: lb_class_only
+          value: "true"
         - name: enableServicesElection
           value: "true"
         {{- range .Values.stack.kubevip.additionalEnv }}


### PR DESCRIPTION
Kube-vip deployed by this chart is also trying to manage LoadBalancer IPs of any external service requesting for a LB IP. Ideally kube-vip should only manage IPs for those services that have LoadBalancerClass set to kube-vip.io/kube-vip-class on the service. This change adds the necessary env in the kube-vip config to only manager the LB Ips for the services with LB class set.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
