### PR TITLE
Switch roles to clusterroles

### DIFF
--- a/tinkerbell/hegel/templates/role.yaml
+++ b/tinkerbell/hegel/templates/role.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ .Values.roleName }}
-  namespace: {{ .Release.Namespace | quote }}
 rules:
   - apiGroups:
       - tinkerbell.org

--- a/tinkerbell/hegel/templates/role.yaml
+++ b/tinkerbell/hegel/templates/role.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.deploy }}
+{{- if and .Values.deploy .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.roleName }}
+  name: {{ coalesce .Values.roleName .Values.rbac.roleName }}
 rules:
   - apiGroups:
       - tinkerbell.org

--- a/tinkerbell/hegel/templates/rolebinding.yaml
+++ b/tinkerbell/hegel/templates/rolebinding.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.deploy }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.roleBindingName }}
-  namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ .Values.roleName }}
 subjects:
   - kind: ServiceAccount

--- a/tinkerbell/hegel/templates/rolebinding.yaml
+++ b/tinkerbell/hegel/templates/rolebinding.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.deploy }}
+{{- if and .Values.deploy .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.roleBindingName }}
+  name: {{ coalesce .Values.roleBindingName .Values.rbac.roleBindingName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.roleName }}
+  name: {{ coalesce .Values.roleName .Values.rbac.roleName }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.name }}

--- a/tinkerbell/hegel/values.yaml
+++ b/tinkerbell/hegel/values.yaml
@@ -15,8 +15,10 @@ resources:
   requests:
     cpu: 10m
     memory: 64Mi
-roleName: hegel-role
-roleBindingName: hegel-rolebinding
+rbac:
+  enabled: true
+  roleName: hegel-role
+  roleBindingName: hegel-rolebinding
 nodeSelector: {}
 
 # Trusted proxies defines a list of IP or CIDR ranges that are allowed to set the X-Forwarded-For


### PR DESCRIPTION
## Description

Accompanies pull request https://github.com/tinkerbell/hegel/pull/370

## Why is this needed

If hegel is going to read from multiple namespaces it need accompanying rbac

## How are existing users impacted? What migration steps/scripts do we need?

May break compatibility if a user is running in an environment where they are not allowed to roll out cluster-rbac resources ?
Otherwise there should be no impact.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
