### PR TITLE
Enable generic settting of tolerations and affinity for smee deployment

### DIFF
--- a/tinkerbell/smee/templates/deployment.yaml
+++ b/tinkerbell/smee/templates/deployment.yaml
@@ -120,9 +120,17 @@ spec:
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
-      {{- if .Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled }}
+      {{- if or .Values.deployment.tolerations .Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled }}
       tolerations:
+      {{- .Values.deployment.tolerations | toYaml | nindent 8 }}
+      {{- if .Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled }}
       {{- include "singleNodeClusterConfig" . | indent 6 }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.deployment.affinity }}
+      affinity:
+        {{- .Values.deployment.affinity | toYaml | nindent 8 }}
+      {{- else if .Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled }}
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/tinkerbell/smee/values.yaml
+++ b/tinkerbell/smee/values.yaml
@@ -23,6 +23,8 @@ resources:
 deployment:
   strategy:
     type: RollingUpdate
+  tolerations: []
+  affinity: {}
 
 # The log level for the container.
 logLevel: "info"


### PR DESCRIPTION
## Description

Adds generic `tolerations` and `affinity` fields to the values

## Why is this needed

This way, users have more control over where the smee pod is running.

We have a setup where a specific node is added to the management-cluster, which is in the same L2 network as the machines that are being provisioned (as is required by dhcp).

(Before this we had a separate vm running in the target network, running smee with extra configurations so that it can grab the required configurations from the management cluster externally, but that setup is way more complicated, having to put serviceaccount tokens in there and everything)

## How Has This Been Tested?

With this new chart setup, added specific tolerations and affinity that target a taint/label on the 'special' node which is in the target network.  After that, provisioned some machines which worked fine.

## How are existing users impacted? What migration steps/scripts do we need?

Shouldn't impact anyone in any way.

However, this would open the door to removing the singleNodeClusterConfig code and just documenting how these settings can be used on a single node cluster.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
