### PR TITLE
fixing kubevip documented value paths

### DIFF
--- a/tinkerbell/stack/README.md
+++ b/tinkerbell/stack/README.md
@@ -88,13 +88,13 @@ helm upgrade stack-release stack/ --namespace tink-system --wait
 
 | Name | Description | Value |
 | ---- | ----------- | ----- |
-| `kubevip.enabled` | Enable the deployment of the kube-vip load balancer | `true` |
-| `kubevip.name` | Name for the kube-vip load balancer service | `kube-vip` |
-| `kubevip.image` | Image to use for the kube-vip load balancer | `ghcr.io/kube-vip/kube-vip:v0.5.0` |
-| `kubevip.imagePullPolicy` | Image pull policy to use for kube-vip | `IfNotPresent` |
-| `kubevip.roleName` | Role name to use for the kube-vip load service | `kube-vip-role` |
-| `kubevip.roleBindingName` | Role binding name to use for the kube-vip load service | `kube-vip-rolebinding` |
-| `kubevip.interface` | Interface to use for advertizing the load balancer IP. Leaving it unset to allow Kubevip to auto discover the interface to use. | `""` |
+| `stack.kubevip.enabled` | Enable the deployment of the kube-vip load balancer | `true` |
+| `stack.kubevip.name` | Name for the kube-vip load balancer service | `kube-vip` |
+| `stack.kubevip.image` | Image to use for the kube-vip load balancer | `ghcr.io/kube-vip/kube-vip:v0.5.0` |
+| `stack.kubevip.imagePullPolicy` | Image pull policy to use for kube-vip | `IfNotPresent` |
+| `stack.kubevip.roleName` | Role name to use for the kube-vip load service | `kube-vip-role` |
+| `stack.kubevip.roleBindingName` | Role binding name to use for the kube-vip load service | `kube-vip-rolebinding` |
+| `stack.kubevip.interface` | Interface to use for advertizing the load balancer IP. Leaving it unset to allow Kubevip to auto discover the interface to use. | `""` |
 
 ### DHCP Relay Parameters
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Updating docs to provide correct paths

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #121 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested by adding 
```yaml
stack: 
  kubevip:
    enabled: false
```
to my helm overrides and confirmed it disabled the kubevip deployment.

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->
If they were following the docs, no configurations were actually set.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
