### PR TITLE
Make `presentGiaddrAction: forward`, the default:

### DIFF
--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -60,7 +60,7 @@ stack:
     # maintaining option (82) in its received state from the dhcrelay might be essential.
     # This behavior can be regulated by configuring the presentGiaddrAction as "forward."
     # Additional information is available at: https://linux.die.net/man/8/dhcrelay
-    presentGiaddrAction: append
+    presentGiaddrAction: forward
     # sourceInterface is the Host/Node interface to use for listening for DHCP broadcast packets.
     # When unset, the interface from the default route will be used.
     # sourceInterface: eno1


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This should help the stack deployment work natively for more environments with DHCP relays in play.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
