### PR TITLE
Improve rbac setting by using Helm globals:

### DIFF
--- a/tinkerbell/hegel/templates/deployment.yaml
+++ b/tinkerbell/hegel/templates/deployment.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.deploy }}
+{{- $trustedProxies := .Values.trustedProxies }}
+{{- $roleType := .Values.rbac.type }}
+{{- if .Values.global }}
+{{- $trustedProxies = coalesce .Values.trustedProxies .Values.global.trustedProxies }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.rbac.type }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,7 +38,7 @@ spec:
         - args:
           - --backend=kubernetes
           - --http-addr=:{{ .Values.deployment.port }}
-          {{- if eq .Values.rbac.type "Role"}}
+          {{- if eq $roleType "Role"}}
           - --kubernetes-namespace={{ .Release.Namespace }}
           {{- end }}
           {{- range .Values.args }}
@@ -40,7 +46,7 @@ spec:
           {{- end }}
           env:
             - name: HEGEL_TRUSTED_PROXIES
-              value: {{ required "missing trustedProxies" ( join "," .Values.trustedProxies | quote ) }}
+              value: {{ required "missing trustedProxies" ( join "," $trustedProxies | quote ) }}
             {{- range $i, $env := .Values.env }}
             - name: {{ $env.name | quote }}
               value: {{ $env.value | quote }}

--- a/tinkerbell/hegel/templates/role.yaml
+++ b/tinkerbell/hegel/templates/role.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.deploy }}
+{{- $roleType := .Values.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ .Values.rbac.type }}
+kind: {{ $roleType }}
 metadata:
   name: {{ .Values.rbac.name }}
-  {{- if eq .Values.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 rules:

--- a/tinkerbell/hegel/templates/rolebinding.yaml
+++ b/tinkerbell/hegel/templates/rolebinding.yaml
@@ -1,14 +1,18 @@
 {{- if .Values.deploy }}
+{{- $roleType := .Values.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ printf "%sBinding" .Values.rbac.type }}
+kind: {{ printf "%sBinding" $roleType }}
 metadata:
   name: {{ .Values.rbac.bindingName }}
-  {{- if eq .Values.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{ .Values.rbac.type }}
+  kind: {{ $roleType }}
   name: {{ .Values.rbac.name }}
 subjects:
   - kind: ServiceAccount

--- a/tinkerbell/hegel/values.schema.json
+++ b/tinkerbell/hegel/values.schema.json
@@ -23,10 +23,7 @@
           "port": {
             "type": "integer"
           }
-        },
-        "required": [
-          "port"
-        ]
+        }
       },
       "deployment": {
         "type": "object",
@@ -37,11 +34,7 @@
           "portName": {
             "type": "string"
           }
-        },
-        "required": [
-          "port",
-          "portName"
-        ]
+        }
       },
       "resources": {
         "type": "object",
@@ -55,11 +48,7 @@
               "memory": {
                 "type": "string"
               }
-            },
-            "required": [
-              "cpu",
-              "memory"
-            ]
+            }
           },
           "requests": {
             "type": "object",
@@ -70,17 +59,9 @@
               "memory": {
                 "type": "string"
               }
-            },
-            "required": [
-              "cpu",
-              "memory"
-            ]
+            }
           }
-        },
-        "required": [
-          "limits",
-          "requests"
-        ]
+        }
       },
       "rbac": {
         "type": "object",
@@ -95,12 +76,7 @@
           "bindingName": {
             "type": "string"
           }
-        },
-        "required": [
-          "type",
-          "name",
-          "bindingName"
-        ]
+        }
       },
       "nodeSelector": {
         "type": "object"
@@ -118,25 +94,7 @@
           "nodeAffinityWeight": {
             "type": "integer"
           }
-        },
-        "required": [
-          "controlPlaneTolerationsEnabled",
-          "nodeAffinityWeight"
-        ]
+        }
       }
-    },
-    "required": [
-      "deploy",
-      "name",
-      "image",
-      "imagePullPolicy",
-      "replicas",
-      "service",
-      "deployment",
-      "resources",
-      "rbac",
-      "nodeSelector",
-      "trustedProxies",
-      "singleNodeClusterConfig"
-    ]
+    }
   }

--- a/tinkerbell/rufio/templates/deployment.yaml
+++ b/tinkerbell/rufio/templates/deployment.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.deploy }}
+{{- $roleType := .Values.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.rbac.type }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,7 +45,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        {{- if eq .Values.rbac.type "Role" }}
+        {{- if eq $roleType "Role" }}
         - -kube-namespace={{ .Release.Namespace }}
         {{- end }}
         {{- range .Values.additionalArgs }}

--- a/tinkerbell/rufio/templates/role-binding.yaml
+++ b/tinkerbell/rufio/templates/role-binding.yaml
@@ -1,14 +1,18 @@
 {{- if .Values.deploy }}
+{{- $roleType := .Values.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ printf "%sBinding" .Values.rbac.type }}
+kind: {{ printf "%sBinding" $roleType }}
 metadata:
   name: {{ .Values.rbac.bindingName }}
-  {{- if eq .Values.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{ .Values.rbac.type }}
+  kind: {{ $roleType }}
   name: {{ .Values.rbac.name }}
 subjects:
 - kind: ServiceAccount

--- a/tinkerbell/rufio/templates/role.yaml
+++ b/tinkerbell/rufio/templates/role.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.deploy }}
+{{- $roleType := .Values.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ .Values.rbac.type }}
+kind: {{ $roleType }}
 metadata:
   name: {{ .Values.rbac.name }}
-  {{- if eq .Values.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 rules:

--- a/tinkerbell/rufio/values.schema.json
+++ b/tinkerbell/rufio/values.schema.json
@@ -26,11 +26,7 @@
               "memory": {
                 "type": "string"
               }
-            },
-            "required": [
-              "cpu",
-              "memory"
-            ]
+            }
           },
           "limits": {
             "type": "object",
@@ -41,17 +37,9 @@
               "memory": {
                 "type": "string"
               }
-            },
-            "required": [
-              "cpu",
-              "memory"
-            ]
+            }
           }
-        },
-        "required": [
-          "requests",
-          "limits"
-        ]
+        }
       },
       "additionalArgs": {
         "type": "array",
@@ -81,11 +69,7 @@
           "nodeAffinityWeight": {
             "type": "integer"
           }
-        },
-        "required": [
-          "controlPlaneTolerationsEnabled",
-          "nodeAffinityWeight"
-        ]
+        }
       },
       "rbac": {
         "type": "object",
@@ -100,27 +84,7 @@
           "bindingName": {
             "type": "string"
           }
-        },
-        "required": [
-          "type",
-          "name",
-          "bindingName"
-        ]
+        }
       }
-    },
-    "required": [
-      "deploy",
-      "name",
-      "image",
-      "imagePullPolicy",
-      "resources",
-      "additionalArgs",
-      "serviceAccountName",
-      "rufioLeaderElectionRoleName",
-      "rufioLeaderElectionRoleBindingName",
-      "nodeSelector",
-      "hostNetwork",
-      "singleNodeClusterConfig",
-      "rbac"
-    ]
+    }
   }

--- a/tinkerbell/smee/templates/deployment.yaml
+++ b/tinkerbell/smee/templates/deployment.yaml
@@ -1,11 +1,19 @@
 {{- if .Values.deploy }}
-{{- $_ := set .Values.dhcp "syslogIp" (default .Values.publicIP .Values.dhcp.syslogIp) }}
-{{- $_ := set .Values.dhcp "ipForPacket" (default .Values.publicIP .Values.dhcp.ipForPacket) }}
-{{- $_ := set .Values.dhcp "tftpIp" (default .Values.publicIP .Values.dhcp.tftpIp) }}
-{{- $_ := set .Values.dhcp.httpIPXE.binaryUrl "host" (default .Values.publicIP .Values.dhcp.httpIPXE.binaryUrl.host) }}
-{{- $_ := set .Values.dhcp.httpIPXE.scriptUrl "host" (default .Values.publicIP .Values.dhcp.httpIPXE.scriptUrl.host) }}
-{{- $_ := set .Values.http.tinkServer "ip" (default .Values.publicIP .Values.http.tinkServer.ip) }}
-{{- $_ := set .Values.http.osieUrl "host" (default .Values.publicIP .Values.http.osieUrl.host) }}
+{{- $publicIP := .Values.publicIP }}
+{{- $trustedProxies := .Values.trustedProxies }}
+{{- $roleType := .Values.rbac.type }}
+{{- if .Values.global }}
+{{- $publicIP = coalesce .Values.publicIP .Values.global.publicIP }}
+{{- $trustedProxies = coalesce .Values.trustedProxies .Values.global.trustedProxies }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.rbac.type }}
+{{- end }}
+{{- $_ := set .Values.dhcp "syslogIp" (default $publicIP .Values.dhcp.syslogIp) }}
+{{- $_ := set .Values.dhcp "ipForPacket" (default $publicIP .Values.dhcp.ipForPacket) }}
+{{- $_ := set .Values.dhcp "tftpIp" (default $publicIP .Values.dhcp.tftpIp) }}
+{{- $_ := set .Values.dhcp.httpIPXE.binaryUrl "host" (default $publicIP .Values.dhcp.httpIPXE.binaryUrl.host) }}
+{{- $_ := set .Values.dhcp.httpIPXE.scriptUrl "host" (default $publicIP .Values.dhcp.httpIPXE.scriptUrl.host) }}
+{{- $_ := set .Values.http.tinkServer "ip" (default $publicIP .Values.http.tinkServer.ip) }}
+{{- $_ := set .Values.http.osieUrl "host" (default $publicIP .Values.http.osieUrl.host) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,7 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - -log-level={{ .Values.logLevel }}
-            {{- if eq .Values.rbac.type "Role"}}
+            {{- if eq $roleType "Role"}}
             - -backend-kube-namespace={{ .Release.Namespace }}
             {{- end }}
             - -dhcp-addr={{ printf "%v:%v" .Values.dhcp.ip .Values.dhcp.port }}
@@ -62,7 +70,7 @@ spec:
             - -osie-url={{include "urlJoiner" (dict "urlDict" .Values.http.osieUrl)}}
             - -tink-server={{ printf "%v:%v" .Values.http.tinkServer.ip .Values.http.tinkServer.port }}
             - -tink-server-tls={{ .Values.http.tinkServer.tls }}
-            - -trusted-proxies={{ required "missing trustedProxies" ( join "," .Values.trustedProxies ) }}
+            - -trusted-proxies={{ required "missing trustedProxies" ( join "," $trustedProxies ) }}
             - -syslog-enabled={{ .Values.syslog.enabled }}
             - -ipxe-script-patch={{ .Values.ipxeScriptPatch }}
             - -tftp-enabled={{ .Values.tftp.enabled }}

--- a/tinkerbell/smee/templates/role-binding.yaml
+++ b/tinkerbell/smee/templates/role-binding.yaml
@@ -1,14 +1,18 @@
 {{- if .Values.deploy }}
+{{- $roleType := .Values.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ printf "%sBinding" .Values.rbac.type }}
+kind: {{ printf "%sBinding" $roleType }}
 metadata:
   name: {{ .Values.rbac.bindingName }}
-  {{- if eq .Values.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{ .Values.rbac.type }}
+  kind: {{ $roleType }}
   name: {{ .Values.rbac.name }}
 subjects:
   - kind: ServiceAccount

--- a/tinkerbell/smee/templates/role.yaml
+++ b/tinkerbell/smee/templates/role.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.deploy }}
+{{- $roleType := .Values.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ .Values.rbac.type }}
+kind: {{ $roleType }}
 metadata:
   name: {{ .Values.rbac.name }}
-  {{- if eq .Values.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 rules:

--- a/tinkerbell/smee/values.schema.json
+++ b/tinkerbell/smee/values.schema.json
@@ -29,11 +29,7 @@
               "memory": {
                 "type": "string"
               }
-            },
-            "required": [
-              "cpu",
-              "memory"
-            ]
+            }
           },
           "requests": {
             "type": "object",
@@ -44,17 +40,9 @@
               "memory": {
                 "type": "string"
               }
-            },
-            "required": [
-              "cpu",
-              "memory"
-            ]
+            }
           }
-        },
-        "required": [
-          "limits",
-          "requests"
-        ]
+        }
       },
       "deployment": {
         "type": "object",
@@ -65,15 +53,9 @@
               "type": {
                 "type": "string"
               }
-            },
-            "required": [
-              "type"
-            ]
+            }
           }
-        },
-        "required": [
-          "strategy"
-        ]
+        }
       },
       "logLevel": {
         "type": "string"
@@ -135,13 +117,7 @@
                   "path": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "scheme",
-                  "host",
-                  "port",
-                  "path"
-                ]
+                }
               },
               "scriptUrl": {
                 "type": "object",
@@ -158,33 +134,11 @@
                   "path": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "scheme",
-                  "host",
-                  "port",
-                  "path"
-                ]
+                }
               }
-            },
-            "required": [
-              "binaryUrl",
-              "scriptUrl"
-            ]
+            }
           }
-        },
-        "required": [
-          "enabled",
-          "name",
-          "mode",
-          "ip",
-          "port",
-          "ipForPacket",
-          "tftpIp",
-          "tftpPort",
-          "syslogIp",
-          "httpIPXE"
-        ]
+        }
       },
       "tftp": {
         "type": "object",
@@ -204,14 +158,7 @@
           "timeout": {
             "type": "string"
           }
-        },
-        "required": [
-          "enabled",
-          "name",
-          "ip",
-          "port",
-          "timeout"
-        ]
+        }
       },
       "http": {
         "type": "object",
@@ -240,12 +187,7 @@
               "tls": {
                 "type": "boolean"
               }
-            },
-            "required": [
-              "ip",
-              "port",
-              "tls"
-            ]
+            }
           },
           "osieUrl": {
             "type": "object",
@@ -262,13 +204,7 @@
               "path": {
                 "type": "string"
               }
-            },
-            "required": [
-              "scheme",
-              "host",
-              "port",
-              "path"
-            ]
+            }
           },
           "additionalKernelArgs": {
             "type": "array",
@@ -284,19 +220,7 @@
             "type": "array",
             "items": {}
           }
-        },
-        "required": [
-          "enabled",
-          "name",
-          "ip",
-          "port",
-          "tinkServer",
-          "osieUrl",
-          "additionalKernelArgs",
-          "ipxeBinaryEnabled",
-          "ipxeScriptEnabled",
-          "trustedProxies"
-        ]
+        }
       },
       "syslog": {
         "type": "object",
@@ -313,13 +237,7 @@
           "port": {
             "type": "integer"
           }
-        },
-        "required": [
-          "enabled",
-          "name",
-          "ip",
-          "port"
-        ]
+        }
       },
       "tinkWorkerImage": {
         "type": "string"
@@ -341,11 +259,7 @@
           "nodeAffinityWeight": {
             "type": "integer"
           }
-        },
-        "required": [
-          "controlPlaneTolerationsEnabled",
-          "nodeAffinityWeight"
-        ]
+        }
       },
       "additionalVolumes": {
         "type": "array",
@@ -368,36 +282,7 @@
           "bindingName": {
             "type": "string"
           }
-        },
-        "required": [
-          "type",
-          "name",
-          "bindingName"
-        ]
+        }
       }
-    },
-    "required": [
-      "deploy",
-      "name",
-      "image",
-      "imagePullPolicy",
-      "replicas",
-      "resources",
-      "deployment",
-      "logLevel",
-      "hostNetwork",
-      "nodeSelector",
-      "publicIP",
-      "dhcp",
-      "tftp",
-      "http",
-      "syslog",
-      "tinkWorkerImage",
-      "additionalArgs",
-      "additionalEnv",
-      "singleNodeClusterConfig",
-      "additionalVolumes",
-      "additionalVolumeMounts",
-      "rbac"
-    ]
+    }
   }

--- a/tinkerbell/smee/values.yaml
+++ b/tinkerbell/smee/values.yaml
@@ -37,7 +37,7 @@ nodeSelector: {}
 # publicIP when defined will be used as the IP in the following locations if they are not defined:
 # dhcp.httpIPXE.binaryUrl.host, dhcp.httpIPXE.scriptUrl.host, tinkServer.ip, http.osieUrl.host, dhcp.ipForPacket, dhcp.tftpIp
 # This is useful when all Tinkerbell services are running behind the same IP.
-publicIP: "127.0.0.1"
+publicIP: ""
 
 # DHCP server configuration. Name is an identifier used across Kubernetes manifests for port
 # identification, ip is the IP address to bind to, and port is the port to bind to.

--- a/tinkerbell/stack/README.md
+++ b/tinkerbell/stack/README.md
@@ -7,7 +7,8 @@ This chart installs the full Tinkerbell stack.
 ```bash
 helm dependency build stack/
 trusted_proxies=$(kubectl get nodes -o go-template-file=stack/kubectl.go-template)
-helm install stack-release stack/ --create-namespace --namespace tink-system --wait --set "smee.trustedProxies={${trusted_proxies}}" --set "hegel.trustedProxies={${trusted_proxies}}"
+LB_IP=<IP_ADDRESS>
+helm install stack-release stack/ --create-namespace --namespace tink --wait --set "global.trustedProxies={${trusted_proxies}}" --set "global.publicIP=$LB_IP"
 ```
 
 ## Introduction
@@ -36,7 +37,7 @@ The stack chart does not use an ingress object and controller. This is because m
 
 ## Installing the Chart
 
-Before installing the chart you'll want to customize the IP used for the load balancer (`stack.loadBalancerIP`). This IP provides ingress for Hegel, Tink, and Smee (TFTP, HTTP, and SYSLOG endpoints as well as unicast DHCP requests).
+Before installing the chart you'll want to customize the IP used for the load balancer (`global.publicIP`). This IP provides ingress for Hegel, Tink, and Smee (TFTP, HTTP, and SYSLOG endpoints as well as unicast DHCP requests).
 
 Now, deploy the chart.
 

--- a/tinkerbell/stack/templates/nginx.yaml
+++ b/tinkerbell/stack/templates/nginx.yaml
@@ -161,7 +161,7 @@ spec:
   {{- if .Values.stack.lbClass }}
   loadBalancerClass: {{ .Values.stack.lbClass }}
   {{- end }}
-  loadBalancerIP: {{ .Values.stack.loadBalancerIP }}
+  loadBalancerIP: {{ coalesce .Values.stack.loadBalancerIP .Values.global.publicIP }}
   externalTrafficPolicy: Local
   {{- end }}
   ports:

--- a/tinkerbell/stack/values.schema.json
+++ b/tinkerbell/stack/values.schema.json
@@ -1,0 +1,230 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+      "stack": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "service": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "type": {
+                "type": "string"
+              }
+            }
+          },
+          "selector": {
+            "type": "object",
+            "properties": {
+              "app": {
+                "type": "string"
+              }
+            }
+          },
+          "nodeSelector": {
+            "type": "object"
+          },
+          "deployment": {
+            "type": "object",
+            "properties": {
+              "strategy": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "clusterDomain": {
+            "type": "string"
+          },
+          "loadBalancerIP": {
+            "type": "string"
+          },
+          "lbClass": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string"
+          },
+          "hook": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "name": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer"
+              },
+              "image": {
+                "type": "string"
+              },
+              "downloadsDest": {
+                "type": "string"
+              },
+              "downloadURL": {
+                "type": "string"
+              }
+            }
+          },
+          "kubevip": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "name": {
+                "type": "string"
+              },
+              "image": {
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "type": "string"
+              },
+              "roleName": {
+                "type": "string"
+              },
+              "roleBindingName": {
+                "type": "string"
+              },
+              "additionalEnv": {
+                "type": "array",
+                "items": {}
+              }
+            }
+          },
+          "relay": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "image": {
+                "type": "string"
+              },
+              "initImage": {
+                "type": "string"
+              },
+              "maxHopCount": {
+                "type": "integer"
+              },
+              "presentGiaddrAction": {
+                "type": "string"
+              },
+              "listenBroadcastTraffic": {
+                "type": "boolean"
+              },
+              "interfaceMode": {
+                "type": "string"
+              }
+            }
+          },
+          "singleNodeClusterConfig": {
+            "type": "object",
+            "properties": {
+              "controlPlaneTolerationsEnabled": {
+                "type": "boolean"
+              },
+              "nodeAffinityWeight": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "global": {
+        "type": "object",
+        "properties": {
+          "publicIP": {
+            "type": "string"
+          },
+          "rbac": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["Role", "ClusterRole"]
+              }
+            }
+          }
+        }
+      },
+      "smee": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string"
+          },
+          "tinkWorkerImage": {
+            "type": "string"
+          },
+          "trustedProxies": {
+            "type": "array",
+            "items": {}
+          },
+          "publicIP": {
+            "type": "string"
+          }
+        }
+      },
+      "hegel": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string"
+          },
+          "trustedProxies": {
+            "type": "array",
+            "items": {}
+          }
+        }
+      },
+      "rufio": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string"
+          }
+        }
+      },
+      "tink": {
+        "type": "object",
+        "properties": {
+          "controller": {
+            "type": "object",
+            "properties": {
+              "image": {
+                "type": "string"
+              }
+            }
+          },
+          "server": {
+            "type": "object",
+            "properties": {
+              "image": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/tinkerbell/stack/values.yaml
+++ b/tinkerbell/stack/values.yaml
@@ -12,10 +12,8 @@ stack:
       type: RollingUpdate
   # stack needs to resolve DNS names in the cluster (in .svc.clusterDomain)
   clusterDomain: cluster.local
-  # &publicIP is a YAML anchor. It allows us to define a value once and reference it multiple times.
-  # https://helm.sh/docs/chart_template_guide/yaml_techniques/#yaml-anchors
-  # If --set is used for loadBalancerIP, it will not be reflected in the references to the yaml anchor.
-  loadBalancerIP: &publicIP 192.168.2.112
+  # loadBalancerIP will override the global.publicIP value if set
+  # loadBalancerIP: 192.168.2.112
   lbClass: kube-vip.io/kube-vip-class
   # Once the Kubernetes Gateway API is more stable, we will use that for all services instead of nginx.
   image: nginx:1.25.1
@@ -85,12 +83,9 @@ stack:
 smee:
   image: quay.io/tinkerbell/smee:v0.13.0
   tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.11.0
-  trustedProxies: []
-  publicIP: *publicIP
 
 hegel:
   image: quay.io/tinkerbell/hegel:v0.13.0
-  trustedProxies: []
 
 rufio:
   image: quay.io/tinkerbell/rufio:v0.4.1
@@ -100,3 +95,11 @@ tink:
     image: quay.io/tinkerbell/tink-controller:v0.11.0
   server:
     image: quay.io/tinkerbell/tink:v0.11.0
+
+# -- Global values
+global:
+  # publicIP is used to set what both smee.publicIP and stack.loadBalancerIP do individually.
+  publicIP: 192.168.2.113
+  trustedProxies: []
+  rbac:
+    type: Role

--- a/tinkerbell/tink/templates/tink-controller/deployment.yaml
+++ b/tinkerbell/tink/templates/tink-controller/deployment.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.controller.deploy }}
+{{- $roleType := .Values.controller.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.controller.rbac.type }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,7 +28,7 @@ spec:
         - image: {{ .Values.controller.image }}
           imagePullPolicy: {{ .Values.controller.imagePullPolicy }}
           args:
-          {{- if eq .Values.controller.rbac.type "Role" }}
+          {{- if eq $roleType "Role" }}
           - --namespace={{ .Release.Namespace }}
           {{- end }}
           {{- range .Values.controller.args }}

--- a/tinkerbell/tink/templates/tink-controller/role-binding.yaml
+++ b/tinkerbell/tink/templates/tink-controller/role-binding.yaml
@@ -1,14 +1,18 @@
 {{- if .Values.controller.deploy }}
+{{- $roleType := .Values.controller.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.controller.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ .Values.controller.rbac.type }}Binding
+kind: {{ $roleType }}Binding
 metadata:
   name: {{ .Values.controller.rbac.bindingName }}
-  {{- if eq .Values.controller.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{ .Values.controller.rbac.type }}
+  kind: {{ $roleType }}
   name: {{ .Values.controller.rbac.name }}
 subjects:
   - kind: ServiceAccount

--- a/tinkerbell/tink/templates/tink-controller/role.yaml
+++ b/tinkerbell/tink/templates/tink-controller/role.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.controller.deploy }}
+{{- $roleType := .Values.controller.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.controller.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ .Values.controller.rbac.type }}
+kind: {{ $roleType }}
 metadata:
   name: {{ .Values.controller.rbac.name }}
-  {{- if eq .Values.controller.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 rules:

--- a/tinkerbell/tink/templates/tink-server/deployment.yaml
+++ b/tinkerbell/tink/templates/tink-server/deployment.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.server.deploy }}
+{{- $roleType := .Values.server.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.server.rbac.type }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,7 +35,7 @@ spec:
       containers:
         - args:
             - --backend=kubernetes
-            {{- if eq .Values.server.rbac.type "Role"}}
+            {{- if eq $roleType "Role"}}
             - --kube-namespace={{ .Release.Namespace }}
             {{- end }}
             {{- range .Values.server.args }}

--- a/tinkerbell/tink/templates/tink-server/role-binding.yaml
+++ b/tinkerbell/tink/templates/tink-server/role-binding.yaml
@@ -1,14 +1,18 @@
 {{- if .Values.server.deploy }}
+{{- $roleType := .Values.server.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.server.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ printf "%sBinding" .Values.server.rbac.type }}
+kind: {{ printf "%sBinding" $roleType }}
 metadata:
   name: {{ .Values.server.rbac.bindingName }}
-  {{- if eq .Values.server.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{ .Values.server.rbac.type }}
+  kind: {{ $roleType }}
   name: {{ .Values.server.rbac.name }}
 subjects:
   - kind: ServiceAccount

--- a/tinkerbell/tink/templates/tink-server/role.yaml
+++ b/tinkerbell/tink/templates/tink-server/role.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.server.deploy }}
+{{- $roleType := .Values.server.rbac.type }}
+{{- if .Values.global }}
+{{- $roleType = coalesce .Values.global.rbac.type .Values.server.rbac.type }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ .Values.server.rbac.type }}
+kind: {{ $roleType }}
 metadata:
   name: {{ .Values.server.rbac.name }}
-  {{- if eq .Values.server.rbac.type "Role"  }}
+  {{- if eq $roleType "Role"  }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
 rules:

--- a/tinkerbell/tink/values.schema.json
+++ b/tinkerbell/tink/values.schema.json
@@ -37,11 +37,7 @@
                   "memory": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "cpu",
-                  "memory"
-                ]
+                }
               },
               "requests": {
                 "type": "object",
@@ -52,17 +48,9 @@
                   "memory": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "cpu",
-                  "memory"
-                ]
+                }
               }
-            },
-            "required": [
-              "limits",
-              "requests"
-            ]
+            }
           },
           "tinkLeaderElectionRoleName": {
             "type": "string"
@@ -82,11 +70,7 @@
               "weight": {
                 "type": "integer"
               }
-            },
-            "required": [
-              "controlPlaneTolerationsEnabled",
-              "weight"
-            ]
+            }
           },
           "rbac": {
             "type": "object",
@@ -101,28 +85,9 @@
               "bindingName": {
                 "type": "string"
               }
-            },
-            "required": [
-              "type",
-              "name",
-              "bindingName"
-            ]
+            }
           }
-        },
-        "required": [
-          "deploy",
-          "name",
-          "image",
-          "imagePullPolicy",
-          "replicas",
-          "args",
-          "resources",
-          "tinkLeaderElectionRoleName",
-          "tinkLeaderElectionRoleBindingName",
-          "nodeSelector",
-          "singleNodeClusterConfig",
-          "rbac"
-        ]
+        }
       },
       "server": {
         "type": "object",
@@ -148,10 +113,7 @@
               "port": {
                 "type": "integer"
               }
-            },
-            "required": [
-              "port"
-            ]
+            }
           },
           "deployment": {
             "type": "object",
@@ -162,11 +124,7 @@
               "portName": {
                 "type": "string"
               }
-            },
-            "required": [
-              "port",
-              "portName"
-            ]
+            }
           },
           "resources": {
             "type": "object",
@@ -180,11 +138,7 @@
                   "memory": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "cpu",
-                  "memory"
-                ]
+                }
               },
               "requests": {
                 "type": "object",
@@ -195,17 +149,9 @@
                   "memory": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "cpu",
-                  "memory"
-                ]
+                }
               }
-            },
-            "required": [
-              "limits",
-              "requests"
-            ]
+            }
           },
           "nodeSelector": {
             "type": "object"
@@ -219,11 +165,7 @@
               "nodeAffinityWeight": {
                 "type": "integer"
               }
-            },
-            "required": [
-              "controlPlaneTolerationsEnabled",
-              "nodeAffinityWeight"
-            ]
+            }
           },
           "rbac": {
             "type": "object",
@@ -238,31 +180,9 @@
               "bindingName": {
                 "type": "string"
               }
-            },
-            "required": [
-              "type",
-              "name",
-              "bindingName"
-            ]
+            }
           }
-        },
-        "required": [
-          "deploy",
-          "name",
-          "image",
-          "imagePullPolicy",
-          "replicas",
-          "service",
-          "deployment",
-          "resources",
-          "nodeSelector",
-          "singleNodeClusterConfig",
-          "rbac"
-        ]
+        }
       }
-    },
-    "required": [
-      "controller",
-      "server"
-    ]
+    }
   }


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows all rbac to be toggled between Role and ClusterRole. It also simplifies the trustedProxies for Hegel and Smee and the loadBalancerIP/publicIP shared between the stack and Smee. The Helm install experience is improved, in my opinion.

I also removed all the required fields in the values.schema.json so that flexibility of configuration is not limited.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
