### PR TITLE
remove hostnetwork check for addr configuration of the smee services

### DIFF
--- a/tinkerbell/smee/templates/deployment.yaml
+++ b/tinkerbell/smee/templates/deployment.yaml
@@ -78,7 +78,6 @@ spec:
             - -tftp-timeout={{ .Values.tftp.timeout }}
             - -tftp-port={{ .Values.tftp.port }}
             - -syslog-port={{ .Values.syslog.port }}
-            {{- if not .Values.hostNetwork }}
             - -http-addr={{ .Values.http.ip }}
             - -syslog-addr={{ .Values.syslog.ip }}
             - -tftp-addr={{ .Values.tftp.ip }}
@@ -87,7 +86,6 @@ spec:
             - -dhcp-syslog-ip={{ .Values.dhcp.syslogIp }}
             - -dhcp-tftp-ip={{ .Values.dhcp.tftpIp }}
             - -dhcp-ip-for-packet={{ .Values.dhcp.ipForPacket }}
-            {{- end }}
           {{- range .Values.additionalArgs }}
             - {{ . }}
           {{- end }}


### PR DESCRIPTION
## Description

Due to a special network configuration, we have to run smee in the host network so that dhcp requests can  be received and be responded to the destination host.

It looks like the IP of an undesired interface is being used by default.
eno8303 = wrong
lcm@infra = correct

```
2: eno8303: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000                                                                           
    link/ether c4:cb:e1:a6:9e:e0 brd ff:ff:ff:ff:ff:ff                                                                                                                     
    altname enp4s0f0                                                                                                                                                       
    inet 10.144.1.75/24 brd 10.144.1.255 scope global eno8303                                                                                                              
       valid_lft forever preferred_lft forever                                                                                                                             
    inet6 fe80::c6cb:e1ff:fea6:9ee0/64 scope link                                                                                                                          
       valid_lft forever preferred_lft forever                                                                                                                             
...
199: lcm@infra: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue state UP group default qlen 1000                                                                  
    link/ether b8:3f:d2:b9:31:04 brd ff:ff:ff:ff:ff:ff                                                                                                                     
    inet 192.168.178.41/24 brd 192.168.178.255 scope global lcm                                                                                                            
       valid_lft forever preferred_lft forever                                                                                                                             
    inet6 fe80::ba3f:d2ff:feb9:3104/64 scope link                                                                                                                          
       valid_lft forever preferred_lft forever  
```

smee configuration
```
smee:                                                                                                                                                                      
  deploy: true                                                                                                                                                             
  replicas: 1                                                                                                                                                              
  hostNetwork: true                                                                                                                                                                                                                                                                           
  publicIP: "192.168.178.41"                                                                                                                                               
  http:                                                                                                                                                                    
    ip: "192.168.178.41"                                                                                                                                                   
    osieUrl:
      port: 8085
  tftp:
    ip: "192.168.178.41"
  syslog:
    ip: "192.168.178.41"
  dhcp:
    ip: "0.0.0.0"
  additionalKernelArgs:
    - "insecure_registries=192.168.178.41:5000"
```

smee logs
```
{"level":"info","ts":1730481236.732561,"caller":"smee/main.go:146","msg":"starting","version":"ad5ed6f"}
{"level":"info","ts":1730481236.7340803,"caller":"smee/main.go:168","msg":"starting syslog server","bind_addr":"10.144.1.75:514"}
{"level":"info","ts":1730481236.7342365,"caller":"smee/main.go:198","msg":"starting tftp server","bind_addr":"10.144.1.75:69"}
{"level":"info","ts":1730481236.735066,"logger":"github.com/tinkerbell/ipxedust","caller":"ipxedust@v0.0.0-20241012034445-f4626d47a3d8/ipxedust.go:201","msg":"serving iPXE binaries via TFTP","service":"github.com/tinkerbell/smee","addr":"10.144.1.75:69","blocksize":512,"timeout":5,"singlePortEnabled":true}
{"level":"info","ts":1730481236.819109,"caller":"smee/main.go:252","msg":"serving http","addr":"10.144.1.75:7171","trusted_proxies":["fd1c:3eec:d511::/48"]}
{"level":"info","ts":1730481236.8235667,"caller":"smee/main.go:265","msg":"starting dhcp server","bind_addr":"0.0.0.0:67"}
{"level":"info","ts":1730481236.8238513,"caller":"server/dhcp.go:35","msg":"Server listening on","addr":"0.0.0.0:67"}
```


It is currently the case that the IP addresses cannot be changed, as they can only be set due to the host network check if smee is not running in the host network.
```
            {{- if not .Values.hostNetwork }}
            - -http-addr={{ .Values.http.ip }}
            - -syslog-addr={{ .Values.syslog.ip }}
            - -tftp-addr={{ .Values.tftp.ip }}
            - -dhcp-http-ipxe-binary-host={{ .Values.dhcp.httpIPXE.binaryUrl.host}}
            - -dhcp-http-ipxe-script-host={{ .Values.dhcp.httpIPXE.scriptUrl.host }}
            - -dhcp-syslog-ip={{ .Values.dhcp.syslogIp }}
            - -dhcp-tftp-ip={{ .Values.dhcp.tftpIp }}
            - -dhcp-ip-for-packet={{ .Values.dhcp.ipForPacket }}
            {{- end }}
```

I think that a check is not necessary at this point, which is why I have removed it in order to set the correct IP address of the correct interface.

smee logs after my change
```
{"level":"info","ts":1730481698.4865901,"caller":"smee/main.go:146","msg":"starting","version":"ad5ed6f"}
{"level":"info","ts":1730481698.526869,"caller":"smee/main.go:168","msg":"starting syslog server","bind_addr":"192.168.178.41:514"}
{"level":"info","ts":1730481698.5269635,"caller":"smee/main.go:198","msg":"starting tftp server","bind_addr":"192.168.178.41:69"}
{"level":"info","ts":1730481698.5277019,"logger":"github.com/tinkerbell/ipxedust","caller":"ipxedust@v0.0.0-20241012034445-f4626d47a3d8/ipxedust.go:201","msg":"serving iPX
E binaries via TFTP","service":"github.com/tinkerbell/smee","addr":"192.168.178.41:69","blocksize":512,"timeout":5,"singlePortEnabled":true}
{"level":"info","ts":1730481698.53394,"caller":"smee/main.go:252","msg":"serving http","addr":"192.168.178.41:7171","trusted_proxies":["fd1c:3eec:d511::/48"]}
{"level":"info","ts":1730481698.5364258,"caller":"smee/main.go:265","msg":"starting dhcp server","bind_addr":"0.0.0.0:67"}
{"level":"info","ts":1730481698.536558,"caller":"server/dhcp.go:35","msg":"Server listening on","addr":"0.0.0.0:67"}
```

## Why is this needed

We need this change to configure smee correctly in the hostNetwork mode for a deployment


## How Has This Been Tested?
Installed Tinkerbell with the modified smee deployment template and deployed a node

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
