### PR TITLE
Fix controller deployment args

### DIFF
--- a/tinkerbell/tink/templates/tink-controller/deployment.yaml
+++ b/tinkerbell/tink/templates/tink-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           - --namespace={{ .Release.Namespace }}
           {{- end }}
           {{- range .Values.controller.args }}
-            - {{ . }}
+          - {{ . }}
           {{- end }}
           name: {{ .Values.controller.name }}
           resources:


### PR DESCRIPTION
Without patch passing args to tink controller works not correctly.
```Helm
  set_list {
    name  = "tink.controller.args"
    value = ["--log-level=1"]  # debug
  }
```
Resulted pod:
```yaml
      args:
        - '--namespace=tink-system - --log-level=1'
```

## Description

Tink Controller Chart pass args not correctly.

## Why is this needed
For instance, for passing `--log-level`


## How Has This Been Tested?

I didn't test it, but in another module use the same construction and works correctly: https://github.com/tinkerbell/charts/blob/29de47ae2be2581247573f03b613ac3214c38be3/tinkerbell/tink/templates/tink-server/deployment.yaml#L42


## How are existing users impacted? What migration steps/scripts do we need?

Tink Controller Chart pass args not correctly.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
