### PR TITLE
Yaml format Smee chart, align trustedProxies properly:

### DIFF
--- a/tinkerbell/smee/Chart.yaml
+++ b/tinkerbell/smee/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/smee/values.yaml
+++ b/tinkerbell/smee/values.yaml
@@ -54,17 +54,16 @@ dhcp:
   tftpPort: 69
   syslogIp: ""
   httpIPXE:
-      binaryUrl: # http://<host>:<port>/ipxe
-        scheme: "http"
-        host: ""
-        port: 7171
-        path: "/ipxe"
-      scriptUrl: # http://<host>:<port>/auto.ipxe
-        scheme: "http"
-        host: ""
-        port: 7171
-        path: "/auto.ipxe"
-
+    binaryUrl: # http://<host>:<port>/ipxe
+      scheme: "http"
+      host: ""
+      port: 7171
+      path: "/ipxe"
+    scriptUrl: # http://<host>:<port>/auto.ipxe
+      scheme: "http"
+      host: ""
+      port: 7171
+      path: "/auto.ipxe"
 
 # TFTP server configuration used to serve iPXE binaries. Name is an identifier used across
 # Kubernetes manifests for port identification, ip is the IP address to bind to, and port is the
@@ -113,8 +112,8 @@ iso:
   url: ""
 
 # Trusted proxies defines a list of IP or CIDR ranges that are allowed to set the X-Forwarded-For
-  # header. This typically requires all Pod CIDRs in the cluster.
-  trustedProxies: []
+# header. This typically requires all Pod CIDRs in the cluster.
+trustedProxies: []
 
 # Syslog server configuration for the smee hosted syslog server. Name is an identifier used across
 # Kubernetes manifests for port identification, ip is the IP address to bind to, and port is the
@@ -127,7 +126,6 @@ syslog:
 
 # The Tink Worker image passed to OSIE as a kernel arg for launching.
 tinkWorkerImage: quay.io/tinkerbell/tink-worker:v0.12.1
-
 
 # Additional arguments to pass to the smee container. Some arguments are already defined - refer
 # to the deployment.yaml template for details.
@@ -148,14 +146,14 @@ singleNodeClusterConfig:
   nodeAffinityWeight: 1
 
 # Additional volumes on the output Deployment definition.
-additionalVolumes: [ ]
+additionalVolumes: []
 #  - name: foo
 #    secret:
 #      secretName: mysecret
 #      optional: false
 
 # Additional volumeMounts on the Smee container
-additionalVolumeMounts: [ ]
+additionalVolumeMounts: []
 #  - name: foo
 #    mountPath: "/etc/foo"
 #    readOnly: true

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.3.0
 - name: smee
   repository: file://../smee
-  version: 0.6.2
+  version: 0.6.3
 - name: rufio
   repository: file://../rufio
   version: 0.4.0
 - name: hegel
   repository: file://../hegel
   version: 0.4.1
-digest: sha256:fede76afbde378fe066fa9076c7c416d4f049306f31bfbc68139692749a45854
-generated: "2024-12-06T12:39:53.980909198-07:00"
+digest: sha256:7a9249a7849f8ad58fdf6447a925354d7e9141b4b0337db6e0c2bcbeac14dfd3
+generated: "2024-12-23T10:37:48.271651374-07:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     version: "0.3.0"
     repository: "file://../tink"
   - name: smee
-    version: "0.6.2"
+    version: "0.6.3"
     repository: "file://../smee"
   - name: rufio
     version: "0.4.0"


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
There were inconsistency in the formatting of the Smee chart. The trustedProxies was not all the way left when it should have been. It doesn't appear to affect it being set properly but needed fixed regardless.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
