### PR TITLE
Add CAPI labels to machines.bmc and hardware CRDs:

### DIFF
--- a/tinkerbell/rufio/Chart.yaml
+++ b/tinkerbell/rufio/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/rufio/crds/bmc.tinkerbell.org_machines.yaml
+++ b/tinkerbell/rufio/crds/bmc.tinkerbell.org_machines.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.4
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""
   name: machines.bmc.tinkerbell.org
 spec:
   group: bmc.tinkerbell.org

--- a/tinkerbell/stack/Chart.lock
+++ b/tinkerbell/stack/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: tink
   repository: file://../tink
-  version: 0.3.0
+  version: 0.3.1
 - name: smee
   repository: file://../smee
   version: 0.6.3
 - name: rufio
   repository: file://../rufio
-  version: 0.4.0
+  version: 0.4.1
 - name: hegel
   repository: file://../hegel
   version: 0.4.1
-digest: sha256:7a9249a7849f8ad58fdf6447a925354d7e9141b4b0337db6e0c2bcbeac14dfd3
-generated: "2024-12-23T10:37:48.271651374-07:00"
+digest: sha256:79b467e8938d7e08dd7ae071629261505c730fa820b38427dd394ed93ab1b764
+generated: "2025-01-04T15:22:20.743184813-07:00"

--- a/tinkerbell/stack/Chart.yaml
+++ b/tinkerbell/stack/Chart.yaml
@@ -26,13 +26,13 @@ appVersion: "0.6.2"
 
 dependencies:
   - name: tink
-    version: "0.3.0"
+    version: "0.3.1"
     repository: "file://../tink"
   - name: smee
     version: "0.6.3"
     repository: "file://../smee"
   - name: rufio
-    version: "0.4.0"
+    version: "0.4.1"
     repository: "file://../rufio"
   - name: hegel
     version: "0.4.1"

--- a/tinkerbell/tink/Chart.yaml
+++ b/tinkerbell/tink/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/tinkerbell/tink/crds/hardware-crd.yaml
+++ b/tinkerbell/tink/crds/hardware-crd.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""
   name: hardware.tinkerbell.org
 spec:
   group: tinkerbell.org


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
CAPI requires these labels exist on the CRDs when doing a `clusterctl move`.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
